### PR TITLE
🍱 Include xlsx files from additional_inventories.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,7 @@ include premise/data/*.json
 include premise/data/iam_output_files/*.mif
 include premise/data/iam_output_files/*.csv
 include premise/data/iam_output_files/*.xlsx
-include premise/data/additional_inventories/*.xls
+include premise/data/additional_inventories/*.xlsx
 include premise/data/electricity/*.csv
 include premise/data/cement/*.csv
 include premise/data/steel/*.txt


### PR DESCRIPTION
The MANIFEST.in specified xls files, but the files in the repository under `data/additional_inventories` are xlsx.