### PR TITLE
Add "include ~utils/export/*.yaml" to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -33,3 +33,4 @@ include premise/data/utils/*.json
 include premise/data/utils/export/*.csv
 include premise/data/utils/export/*.json
 include premise/data/utils/export/*.yml
+include premise/data/utils/export/*.yaml


### PR DESCRIPTION
The current build (1.0.6) is missing `outdated_flows.yaml` and throws an error at `NewDatabase()` generation.

Updated the MANIFEST.in by including all `*.yaml` files in ~premise/data/utils/export/