### PR TITLE
Update marginal_mixes.py

### DIFF
--- a/premise/data/consequential/leadtimes.yaml
+++ b/premise/data/consequential/leadtimes.yaml
@@ -1,33 +1,33 @@
-Biomass IGCC CCS: 2
-Biomass IGCC: 2
-Biomass CHP: 2
-Biomass CHP CCS: 2
-Biomass ST: 2
+Biomass IGCC CCS: 4
+Biomass IGCC: 4
+Biomass CHP: 4
+Biomass CHP CCS: 4
+Biomass ST: 4
 Coal IGCC: 4
 Coal IGCC CCS: 5
 Coal PC: 4
 Coal PC CCS: 5
 Coal CHP: 4
 Coal CHP CCS: 5
-Gas OC: 2
-Gas CC: 2
+Gas OC: 3
+Gas CC: 3
 Gas CC CCS: 3
-Gas CHP: 2
+Gas CHP: 3
 Gas CHP CCS: 3
 Oil ST: 3
 Oil CC CCS: 3
 Oil CC: 3
 Oil CHP CCS: 3
 Oil CHP: 3
-Geothermal: 1
+Geothermal: 3
 Hydro: 4
-Hydrogen: 1
+Hydrogen: 3
 Nuclear: 7
-Solar CSP: 1
-Solar PV Centralized: 1
-Solar PV Residential: 1
-Wind Onshore: 1
-Wind Offshore: 1
+Solar CSP: 3
+Solar PV Centralized: 2
+Solar PV Residential: 2
+Wind Onshore: 2
+Wind Offshore: 3
 diesel: 3
 petrol: 3
 bioethanol, woody: 3
@@ -40,14 +40,14 @@ diesel, synthetic, hydrogen: 3
 diesel, synthetic, coal: 3
 diesel, synthetic, wood: 3
 diesel, synthetic, wood, with CCS: 3
-natural gas: 2
-biomethane: 2
-hydrogen, electrolysis: 1
-hydrogen, biogas: 1
-hydrogen, biogas, with CCS: 1
-hydrogen, nat. gas: 2
+natural gas: 3
+biomethane: 3
+hydrogen, electrolysis: 3
+hydrogen, biogas: 3
+hydrogen, biogas, with CCS: 3
+hydrogen, nat. gas: 3
 hydrogen, nat. gas, with CCS: 3
-hydrogen, coal: 4
+hydrogen, coal: 3
 bioethanol, grain: 3
 diesel, synthetic, grass: 3
 diesel, synthetic, grass, with CCS: 3

--- a/premise/marginal_mixes.py
+++ b/premise/marginal_mixes.py
@@ -365,12 +365,12 @@ def consequential_method(data: xr.DataArray, year: int, args: dict) -> xr.DataAr
                 new_start[:, :] = start[:, None]
                 start = new_start
 
-            mask_end = data_full.sel(region=region).year.values[None, :] <= end
-            mask_start = data_full.sel(region=region).year.values[None, :] >= start
+            mask_end = data_full.sel(region=region).year <= end
+            mask_start = data_full.sel(region=region).year >= start
+            mask = mask_end & mask_start
 
             masked_data = data_full.sel(region=region).where(
-                (data_full.sel(region=region) <= mask_end)
-                & (data_full.sel(region=region) >= mask_start)
+                mask, drop = True
             )
 
             coeff = masked_data.polyfit(dim="year", deg=1)
@@ -428,12 +428,12 @@ def consequential_method(data: xr.DataArray, year: int, args: dict) -> xr.DataAr
                     year=start,
                 )
 
-            mask_end = data_full.sel(region=region).year.values[None, :] <= end
-            mask_start = data_full.sel(region=region).year.values[None, :] >= start
+            mask_end = data_full.sel(region=region).year <= end
+            mask_start = data_full.sel(region=region).year >= start
+            mask = mask_end & mask_start
 
             masked_data = data_full.sel(region=region).where(
-                (data_full.sel(region=region) <= mask_end)
-                & (data_full.sel(region=region) >= mask_start)
+                mask, drop = True
             )
 
             coeff = masked_data.sum(dim="year").values

--- a/premise/marginal_mixes.py
+++ b/premise/marginal_mixes.py
@@ -593,14 +593,14 @@ def consequential_method(data: xr.DataArray, year: int, args: dict) -> xr.DataAr
                     capital_repl_rate and volume_change < avg_cap_repl_rate
                 ):
                     # we remove suppliers with a positive growth
-                    market_shares.loc[dict(region=region)].values[
-                        market_shares.loc[dict(region=region)].values > 0
+                    market_shares_split.loc[dict(region=region)].values[
+                        market_shares_split.loc[dict(region=region)].values > 0
                     ] = 0
-                    market_shares.loc[dict(region=region)] /= market_shares.loc[
+                    market_shares_split.loc[dict(region=region)] /= market_shares_split.loc[
                         dict(region=region)
                     ].sum(dim="variables")
                     # we reverse the sign so that the suppliers are still seen as negative in the next step
-                    market_shares.loc[dict(region=region)] *= -1
+                    market_shares_split.loc[dict(region=region)] *= -1
 
                 else:
                     # we remove suppliers with a negative growth

--- a/premise/marginal_mixes.py
+++ b/premise/marginal_mixes.py
@@ -557,7 +557,7 @@ def consequential_method(data: xr.DataArray, year: int, args: dict) -> xr.DataAr
             ]
 
         if measurement == 4:
-            n = end - start
+            n = avg_end - avg_start
 
             if isinstance(n, int):
                 n = np.array([n])

--- a/premise/marginal_mixes.py
+++ b/premise/marginal_mixes.py
@@ -187,7 +187,7 @@ def consequential_method(data: xr.DataArray, year: int, args: dict) -> xr.DataAr
                 "start_avg": year,
                 "end_avg": year + fetch_avg_lifetime(lifetime=leadtime, shares=shares),
             },
-            (False, False, True, True): {
+            (False, False, True, False): {
                 "start": year - fetch_avg_leadtime(leadtime, shares),
                 "end": year,
                 "start_avg": year - fetch_avg_leadtime(leadtime, shares),

--- a/premise/marginal_mixes.py
+++ b/premise/marginal_mixes.py
@@ -596,11 +596,11 @@ def consequential_method(data: xr.DataArray, year: int, args: dict) -> xr.DataAr
                     market_shares.loc[dict(region=region)].values[
                         market_shares.loc[dict(region=region)].values > 0
                     ] = 0
-                    # we reverse the sign of negative growth suppliers
-                    market_shares.loc[dict(region=region)] *= -1
                     market_shares.loc[dict(region=region)] /= market_shares.loc[
                         dict(region=region)
                     ].sum(dim="variables")
+                    # we reverse the sign so that the suppliers are still seen as negative in the next step
+                    market_shares.loc[dict(region=region)] *= -1
 
                 else:
                     # we remove suppliers with a negative growth
@@ -673,9 +673,10 @@ def consequential_method(data: xr.DataArray, year: int, args: dict) -> xr.DataAr
                     market_shares.loc[dict(region=region)].values >= 0
                 ] = 0
                 # we keep suppliers with a negative growth
+                # we use negative 1 so that in the next step they are still seen as negative
                 market_shares.loc[dict(region=region)].values[
                     market_shares.loc[dict(region=region)].values < 0
-                ] = 1
+                ] = -1
                 # and use their production volume as their indicator
                 market_shares.loc[dict(region=region)] *= data_start.values[:, None]
             # increasing market or


### PR DESCRIPTION
There was a problem where, with negative growth, measurement method 4 and 5 would already calculate (part of) the marginal mix, which turned the values positive. In the next general step (starts at line 713) these would then be kicked out because they are positive now, leaving no marginal suppliers. Now they will still be negative and kept as they should be