### PR TITLE
Fix IAM file read-in for external files.

### DIFF
--- a/premise/data_collection.py
+++ b/premise/data_collection.py
@@ -302,7 +302,7 @@ class IAMDataCollection:
 
         data = self.__get_iam_data(
             key=key,
-            filepath=filepath_iam_files,
+            filedir=filepath_iam_files,
             variables=new_vars,
         )
 
@@ -394,7 +394,7 @@ class IAMDataCollection:
         return dict_vars
 
     def __get_iam_data(
-        self, key: bytes, filepath: Path, variables: List
+        self, key: bytes, filedir: Path, variables: List
     ) -> xr.DataArray:
         """
         Read the IAM result file and return an `xarray` with dimensions:
@@ -411,7 +411,7 @@ class IAMDataCollection:
         """
 
         file_ext = self.model + "_" + self.pathway + ".csv"
-        filepath = Path(filepath) / file_ext
+        filepath = Path(filedir) / file_ext
 
         if key is None:
             # Uses a non-encrypted file
@@ -421,7 +421,7 @@ class IAMDataCollection:
                     encrypted_data = file.read()
             except FileNotFoundError:
                 file_ext = self.model + "_" + self.pathway + ".mif"
-                filepath = Path(filepath) / file_ext
+                filepath = Path(filedir) / file_ext
                 with open(filepath, "rb") as file:
                     # read the encrypted data
                     encrypted_data = file.read()


### PR DESCRIPTION
The following error appeared in the un-patched version:
```
File ~/miniconda3/envs/premise/lib/python3.10/site-packages/premise/data_collection.py:422, in IAMDataCollection.__get_iam_data(self, key, filepath, variables)
    420     file_ext = self.model + "_" + self.pathway + ".mif"
    421     filepath = Path(filepath) / file_ext
--> 422     with open(filepath, "rb") as file:
    423         # read the encrypted data
    424         encrypted_data = file.read()
    426 # create a temp csv-like file to pass to pandas.read_csv()

FileNotFoundError: [Errno 2] No such file or directory: '~/remind/testruns/test/remind_default.csv/remind_default.mif'
```