### PR TITLE
brightway version checking

### DIFF
--- a/premise/data/consequential/lifetimes.yaml
+++ b/premise/data/consequential/lifetimes.yaml
@@ -79,3 +79,4 @@ steel - secondary: 40
 daccs_sorbent: 20
 biomass - residual: 35
 biomass crops - purpose grown: 35
+Storage, Hydrogen: 35

--- a/premise/ecoinvent_modification.py
+++ b/premise/ecoinvent_modification.py
@@ -55,12 +55,12 @@ from .utils import (
 logger = logging.getLogger("module")
 
 try:
-    import bw_processing
-
+    import bw2data
+    assert bw2data.__version__[0] >= 4 
     from .brightway25 import write_brightway_database
 
     logger.info("Using Brightway 2.5")
-except ImportError:
+except AssertionError:
     from .brightway2 import write_brightway_database
 
     logger.info("Using Brightway 2")

--- a/premise/ecoinvent_modification.py
+++ b/premise/ecoinvent_modification.py
@@ -55,7 +55,7 @@ from .utils import (
 logger = logging.getLogger("module")
 
 try:
-    import bw_processing
+    import brightway25
 
     from .brightway25 import write_brightway_database
 

--- a/premise/ecoinvent_modification.py
+++ b/premise/ecoinvent_modification.py
@@ -55,7 +55,7 @@ from .utils import (
 logger = logging.getLogger("module")
 
 try:
-    import brightway25
+    import bw_processing
 
     from .brightway25 import write_brightway_database
 

--- a/premise/iam_variables_mapping/electricity_variables.yaml
+++ b/premise/iam_variables_mapping/electricity_variables.yaml
@@ -42,7 +42,7 @@ Biomass CHP (existing):
   ecoinvent_fuel_aliases:
     fltr:
       - market for wood chips, wet, measured as dry mass
-  exists in database: False
+  exists in database: True
   proxy:
     name: heat and power co-generation, wood chips, 6667 kW
     reference product: electricity, high voltage


### PR DESCRIPTION
In ecoinvent_modification.py there is checking for brightway versions via attempted import of bw_processing (which is brightway version agnostic). 

In an env with bw2 and bw_processing, this will lead to premise trying to write a db with .brightway25 instead of .brightway2 which leads to errors like:

```
  File "/home/stew/code/gh/premise/premise/brightway25.py", line 34, in <dictcomp>
    obj.key: obj.id
AttributeError: 'Activity' object has no attribute 'id'
```

Ideally, there could be a check to see if the project is bw2 or bw25, but I couldn't see any easy way to do that. 
Maybe better just to change the import attempt to that below, no? (or did Chris have a reason to use bw2_processing?)
```
try:
    import brightway25