### PR TITLE
Fix lifetimes bug with 'Storage, Hydrogen'

### DIFF
--- a/premise/data/consequential/lifetimes.yaml
+++ b/premise/data/consequential/lifetimes.yaml
@@ -79,3 +79,4 @@ steel - secondary: 40
 daccs_sorbent: 20
 biomass - residual: 35
 biomass crops - purpose grown: 35
+Storage, Hydrogen: 35

--- a/premise/ecoinvent_modification.py
+++ b/premise/ecoinvent_modification.py
@@ -55,7 +55,7 @@ from .utils import (
 logger = logging.getLogger("module")
 
 try:
-    import bw_processing
+    import brightway25
 
     from .brightway25 import write_brightway_database
 

--- a/premise/ecoinvent_modification.py
+++ b/premise/ecoinvent_modification.py
@@ -55,7 +55,7 @@ from .utils import (
 logger = logging.getLogger("module")
 
 try:
-    import brightway25
+    import bw_processing
 
     from .brightway25 import write_brightway_database
 

--- a/premise/iam_variables_mapping/electricity_variables.yaml
+++ b/premise/iam_variables_mapping/electricity_variables.yaml
@@ -42,7 +42,7 @@ Biomass CHP (existing):
   ecoinvent_fuel_aliases:
     fltr:
       - market for wood chips, wet, measured as dry mass
-  exists in database: False
+  exists in database: True
   proxy:
     name: heat and power co-generation, wood chips, 6667 kW
     reference product: electricity, high voltage


### PR DESCRIPTION
When running consequential dbs (doesn't matter which scenario) with the latest premise and bw2, there is a problem that arises at the unpack IAM data stage. See screenshot below.

The array shapes are mismatched in the tech and the lifetimes.

This can be fixed by adding the missing technology 'Storage, Hydrogen' to the lifetimes.yaml (I gave it a 35 yr lifetime, based on the other hydrogen assets)

It's just a one line change (but the commits to this branch are multiple because I haven't done this very often :) )

![image](https://github.com/polca/premise/assets/81536352/4186039f-0a33-4f8c-ae7f-8530aca110d4)
