### PR TITLE
bw2-25 version checking (fixed origin branch)

### DIFF
--- a/premise/ecoinvent_modification.py
+++ b/premise/ecoinvent_modification.py
@@ -55,15 +55,16 @@ from .utils import (
 logger = logging.getLogger("module")
 
 try:
-    import bw_processing
-
+    import bw2data
+    
+    major_version = int(bw2data.__version__.split('.')[0])
+    assert major_version >= 4
+    
     from .brightway25 import write_brightway_database
-
     logger.info("Using Brightway 2.5")
 
-except ImportError:
+except AssertionError:
     from .brightway2 import write_brightway_database
-
     logger.info("Using Brightway 2")
 
 

--- a/premise/ecoinvent_modification.py
+++ b/premise/ecoinvent_modification.py
@@ -57,7 +57,7 @@ logger = logging.getLogger("module")
 try:
     import bw2data
     
-    major_version = int(bw2data.__version__.split('.')[0])
+    major_version = int(bw2data.__version__[0])
     assert major_version >= 4
     
     from .brightway25 import write_brightway_database

--- a/premise/ecoinvent_modification.py
+++ b/premise/ecoinvent_modification.py
@@ -54,16 +54,11 @@ from .utils import (
 
 logger = logging.getLogger("module")
 
-try:
-    import bw2data
-    
-    major_version = int(bw2data.__version__[0])
-    assert major_version >= 4
-    
+import bw2data
+if int(bw2data.__version__[0]) >= 4:
     from .brightway25 import write_brightway_database
     logger.info("Using Brightway 2.5")
-
-except AssertionError:
+else:
     from .brightway2 import write_brightway_database
     logger.info("Using Brightway 2")
 


### PR DESCRIPTION
Moved from [PR#125](https://github.com/polca/premise/pull/125) because it was from the wrong branch.

In ecoinvent_modification.py there is checking for brightway versions via attempted import of bw_processing (which is brightway version agnostic).

In an env with bw2 and bw_processing, this will lead to premise trying to write a db with .brightway25 instead of .brightway2 which leads to errors like:

```
  File "/home/stew/code/gh/premise/premise/brightway25.py", line 34, in <dictcomp>
    obj.key: obj.id
AttributeError: 'Activity' object has no attribute 'id'
```
Ideally, there could be a check to see if the project is bw2 or bw25, but I couldn't see any easy way to do that. 
(I would like to know how to do that in general, so that I don't accidentally change my bw2 projects into bw25)

Maybe better just to change the import attempt to that below, no? (or did Chris have a reason to use bw2_processing?)
```
try:
    import bw2data
    
    major_version = int(bw2data.__version__.split('.')[0])
    assert major_version >= 4
    
    from .brightway25 import write_brightway_database
    logger.info("Using Brightway 2.5")

except AssertionError:
    from .brightway2 import write_brightway_database
    logger.info("Using Brightway 2")
```