### PR TITLE
added_include_time_option

### DIFF
--- a/premise/new_database.py
+++ b/premise/new_database.py
@@ -52,6 +52,7 @@ from .utils import (
     load_constants,
     print_version,
     warning_about_biogenic_co2,
+    generate_filename,
 )
 
 logger = logging.getLogger("module")
@@ -936,6 +937,7 @@ class NewDatabase:
         name: str = f"super_db_{date.today()}",
         filepath: str = None,
         file_format: str = "excel",
+        include_time: bool = False,
     ) -> None:
         """
         Register a super-structure database,
@@ -978,11 +980,13 @@ class NewDatabase:
         )
 
         # generate scenario report
-        self.generate_scenario_report()
+        self.generate_scenario_report(include_time=include_time)
         # generate change report from logs
-        self.generate_change_report()
+        self.generate_change_report(include_time=include_time)
 
-    def write_db_to_brightway(self, name: [str, List[str]] = None):
+    def write_db_to_brightway(
+        self, name: [str, List[str]] = None, include_time: bool = False
+    ):
         """
         Register the new database into an open brightway project.
         :param name: to give a (list) of custom name(s) to the database.
@@ -1033,11 +1037,11 @@ class NewDatabase:
             )
 
         # generate scenario report
-        self.generate_scenario_report()
+        self.generate_scenario_report(include_time=include_time)
         # generate change report from logs
-        self.generate_change_report()
+        self.generate_change_report(include_time=include_time)
 
-    def write_db_to_matrices(self, filepath: str = None):
+    def write_db_to_matrices(self, filepath: str = None, include_time: bool = False):
         """
 
         Exports the new database as a sparse matrix representation in csv files.
@@ -1106,11 +1110,11 @@ class NewDatabase:
                 Export(scenario, filepath[scen], self.version).export_db_to_matrices()
 
         # generate scenario report
-        self.generate_scenario_report()
+        self.generate_scenario_report(include_time=include_time)
         # generate change report from logs
-        self.generate_change_report()
+        self.generate_change_report(include_time=include_time)
 
-    def write_db_to_simapro(self, filepath: str = None):
+    def write_db_to_simapro(self, filepath: str = None, include_time: bool = False):
         """
         Exports database as a CSV file to be imported in Simapro 9.x
 
@@ -1140,11 +1144,11 @@ class NewDatabase:
             Export(scenario, filepath, self.version).export_db_to_simapro()
 
         # generate scenario report
-        self.generate_scenario_report()
+        self.generate_scenario_report(include_time=include_time)
         # generate change report from logs
-        self.generate_change_report()
+        self.generate_change_report(include_time=include_time)
 
-    def write_db_to_olca(self, filepath: str = None):
+    def write_db_to_olca(self, filepath: str = None, include_time: bool = False):
         """
         Exports database as a Simapro CSV file to be imported in OpenLCA
 
@@ -1176,11 +1180,13 @@ class NewDatabase:
             )
 
         # generate scenario report
-        self.generate_scenario_report()
+        self.generate_scenario_report(include_time=include_time)
         # generate change report from logs
-        self.generate_change_report()
+        self.generate_change_report(include_time=include_time)
 
-    def write_datapackage(self, name: str = f"datapackage_{date.today()}"):
+    def write_datapackage(
+        self, name: str = f"datapackage_{date.today()}", include_time: bool = False
+    ):
         if not isinstance(name, str):
             raise TypeError("`name` should be a string.")
 
@@ -1222,20 +1228,23 @@ class NewDatabase:
         )
 
         # generate scenario report
-        self.generate_scenario_report()
+        self.generate_scenario_report(include_time=include_time)
         # generate change report from logs
-        self.generate_change_report()
+        self.generate_change_report(include_time=include_time)
 
     def generate_scenario_report(
         self,
         filepath: [str, Path] = None,
-        name: str = f"scenario_report_{date.today()}.xlsx",
+        report_name: str = "scenario_report",
+        include_time: bool = False,
     ):
         """
         Generate a report of the scenarios.
         """
 
         print("Generate scenario report.")
+
+        name = generate_filename(report_name, include_time, ".xlsx")
 
         if filepath is not None:
             if isinstance(filepath, str):
@@ -1254,14 +1263,14 @@ class NewDatabase:
 
         print(f"Report saved under {filepath}.")
 
-    def generate_change_report(self):
+    def generate_change_report(self, include_time=False):
         """
         Generate a report of the changes between the original database and the scenarios.
         """
 
         print("Generate change report.")
         generate_change_report(
-            self.source, self.version, self.source_type, self.system_model
+            self.source, self.version, self.source_type, self.system_model, include_time
         )
         # saved under working directory
         print(f"Report saved under {os.getcwd()}.")

--- a/premise/report.py
+++ b/premise/report.py
@@ -4,6 +4,7 @@ This module export a summary of scenario to an Excel file.
 
 import os
 from datetime import datetime
+from .utils import generate_filename
 from pathlib import Path
 
 import openpyxl
@@ -520,7 +521,9 @@ def generate_summary_report(scenarios: list, filename: Path) -> None:
     workbook.save(filename)
 
 
-def generate_change_report(source, version, source_type, system_model):
+def generate_change_report(
+    source, version, source_type, system_model, include_time=False
+):
     """
     Generate a change report of the scenarios from the log files.
     """
@@ -611,9 +614,9 @@ def generate_change_report(source, version, source_type, system_model):
 
     # save the workbook in the working directory
     # the file name is change_report with the current date
-    fp = Path(
-        DIR_LOG_REPORT / f"change_report {datetime.now().strftime('%Y-%m-%d')}.xlsx"
-    )
+    base_name = "change_report"
+    report_name = generate_filename(base_name, include_time, ".xlsx")
+    fp = Path(DIR_LOG_REPORT) / report_name
     workbook.save(fp)
 
 

--- a/premise/utils.py
+++ b/premise/utils.py
@@ -9,6 +9,7 @@ from functools import lru_cache
 from numbers import Number
 from pathlib import Path
 from typing import Optional
+from datetime import datetime
 
 import pandas as pd
 import xarray as xr
@@ -26,6 +27,29 @@ from .geomap import Geomap
 FUELS_PROPERTIES = VARIABLES_DIR / "fuels_variables.yaml"
 CROPS_PROPERTIES = VARIABLES_DIR / "crops_variables.yaml"
 EFFICIENCY_RATIO_SOLAR_PV = DATA_DIR / "renewables" / "efficiency_solar_PV.csv"
+
+
+def generate_filename(
+    base_name: str, include_time: bool = False, suffix: str = ""
+) -> str:
+    """
+    Generates a filename with optional inclusion of current time.
+
+    :param base_name: The base name of the file without date or time.
+    :param include_time: Whether to include the current time in the filename.
+    :param suffix: The file extension or suffix.
+    :return: A string representing the formatted filename.
+    """
+    date_format = "%Y-%m-%d"
+    time_format = "%H-%M-%S"
+    current_datetime = datetime.now()
+
+    if include_time:
+        filename = f"{base_name}_{current_datetime.strftime(f'{date_format}_{time_format}')}{suffix}"
+    else:
+        filename = f"{base_name}_{current_datetime.strftime(date_format)}{suffix}"
+
+    return filename
 
 
 def rescale_exchanges(


### PR DESCRIPTION
Hi,

Calling functions like generate_scenario_report or generate_change_report multiple times within the same day results in the subsequent executions overwriting the previously generated files. This behavior, as discussed in issue #160 , requires manual backup actions by users who wish to preserve each generated report.

Since file generation is a common task across various functions within the library, I propose introducing a generate_filename utility function. This function resides within the utils module and offers a standardized approach to filename creation. It accepts a base_name and a boolean flag include_time. When include_time is True, the function appends a timestamp to the filename; otherwise, it only includes the date.

This enhancement has been integrated into the generate_scenario_report and generate_change_report functions through the addition of an include_time parameter, defaulting to False. This maintains backward compatibility with existing workflows while offering users the option to include timestamps in filenames to prevent overwrites. The feature extends to other file-generating functions, such as write_db_to_brightway and write_db_to_matrices, ensuring a consistent and flexible approach to filename generation across the library.

I've tested these changes to ensure they function as expected.

This update should only affect standard users' workflows if the new include_time option is explicitly utilized.

Looking forward to your feedback :)