### PR TITLE
add biosphere_name argument to NewDatabase

### DIFF
--- a/premise/new_database.py
+++ b/premise/new_database.py
@@ -459,13 +459,12 @@ def _export_to_olca(obj):
     obj.export_db_to_simapro(olca_compartments=True)
 
 
-def check_presence_biosphere_database() -> str:
+def check_presence_biosphere_database(biosphere_name: str) -> str:
     """
     Check that the biosphere database is present in the current project.
     """
 
-    biosphere_name = "biosphere3"
-    if "biosphere3" not in bw2data.databases:
+    if biosphere_name not in bw2data.databases:
         print("premise requires the name of your biosphere database.")
         print(
             "Please enter the name of your biosphere database as it appears in your project."
@@ -506,6 +505,7 @@ class NewDatabase:
         keep_uncertainty_data=False,
         gains_scenario="CLE",
         use_absolute_efficiency=False,
+        biosphere_name: str = "biosphere3",
     ) -> None:
         self.source = source_db
         self.version = check_db_version(source_version)
@@ -514,7 +514,7 @@ class NewDatabase:
         self.system_model_args = system_args
         self.use_absolute_efficiency = use_absolute_efficiency
         self.keep_uncertainty_data = keep_uncertainty_data
-        self.biosphere_name = check_presence_biosphere_database()
+        self.biosphere_name = check_presence_biosphere_database(biosphere_name)
 
         # if version is anything other than 3.8 or 3.9
         # and system_model is "consequential"


### PR DESCRIPTION
The biosphere_name is a class variable in NewDatabase, but there is no optional argument for the biosphere_name in the __init__. Instead, the check_presence_of_biosphere_database function checks for the default name "biosphere3" and asks for user input if it's not present. 

I think adding biosphere_name as an optional argument to NewDatabase would be nice to avoid stopping for user inputs when running a script. In my case, I used the ecoinvent_interface to get ei releases. There, the default name of the biosphere is not "biosphere3" anymore, so for me the name input always popped up when creating the premise dbs.

The default behavior of the proposed solution is the same as before, It just allows for defining a custom biosphere name beforehand.