### PR TITLE
Better communication of scenario processing message

### DIFF
--- a/premise/new_database.py
+++ b/premise/new_database.py
@@ -946,9 +946,7 @@ class NewDatabase:
             [item for item in sectors if item not in sector_update_methods]
         )
 
-        with tqdm(
-            total=len(self.scenarios), desc=description, ncols=70
-        ) as pbar_outer:
+        with tqdm(total=len(self.scenarios), desc=description, ncols=70) as pbar_outer:
             for scenario in self.scenarios:
                 # add database to scenarios
                 try:

--- a/premise/new_database.py
+++ b/premise/new_database.py
@@ -926,11 +926,14 @@ class NewDatabase:
         }
 
         if isinstance(sectors, str):
+            description = f"Processing scenarios for sector '{sectors}'"
             sectors = [
                 sectors,
             ]
-
-        if sectors is None:
+        elif isinstance(sectors, list):
+            description = f"Processing scenarios for {len(sectors)} sectors"
+        elif sectors is None:
+            description = "Processing scenarios for all sectors"
             sectors = [s for s in list(sector_update_methods.keys())]
 
         assert isinstance(sectors, list), "sector_name should be a list of strings"
@@ -944,7 +947,7 @@ class NewDatabase:
         )
 
         with tqdm(
-            total=len(self.scenarios), desc="Processing scenarios", ncols=70
+            total=len(self.scenarios), desc=description, ncols=70
         ) as pbar_outer:
             for scenario in self.scenarios:
                 # add database to scenarios


### PR DESCRIPTION
Minor improvement suggestion:

Better messaging to user about sector updates during `nbd.update`

If 1 sector is chosen (e.g. `nbd.update("electricity")`), message becomes: `Processing scenarios for sector 'electricity'`

If multiple sectors are chosen (e.g. `nbd.update(["electricity", "fuel"])`) message becomes: `Processing scenarios for 2 sectors`

If all are used (e.g. `nbd.update()`) message becomes: `Processing scenarios for all sectors`

By only showing max one name (or the amount), the message doesn't become too long, but user will still have a better idea of what is going on, especially when multiple instances of `nbd.update(sector)` are used.