### PR TITLE
fix problem where activities with same name 

### DIFF
--- a/premise/external.py
+++ b/premise/external.py
@@ -464,8 +464,9 @@ class ExternalScenario(BaseTransformation):
             if "regionalize" in ds:
                 del ds["regionalize"]
 
-            if ds["location"] not in regions and ds["name"] not in processed:
-                processed.append(ds["name"])
+            processed_key = (ds["name"], ds["reference product"], ds["unit"])
+            if ds["location"] not in regions and processed_key not in processed:
+                processed.append(processed_key)
 
                 # Check if datasets already exist for IAM regions
                 # if not, create them


### PR DESCRIPTION
Fix problem where activities with same name but different product had to be regionalized.

As discussed on email:
when adding external scenario that regionalizes multiple activities with the same name but different product, only one was regionalized. This was due to the activity being selected based on `name` only. Fix now checks for `name`, `reference product` and `unit`.