### PR TITLE
Update secondary energy mapping for MESSAGE 

### DIFF
--- a/premise/iam_variables_mapping/electricity.yaml
+++ b/premise/iam_variables_mapping/electricity.yaml
@@ -944,7 +944,7 @@ Solar PV Centralized:
   iam_aliases:
     gcam: Secondary Energy|Electricity|PV
     image: Secondary Energy|Electricity|Solar|PV|1
-    message: Secondary Energy|Electricity|Solar|PV
+    message: Secondary Energy|Electricity|Solar|PV|Commercial
     remind: SE|Electricity|Solar|+|PV
     remind-eu: SE|Electricity|Solar|+|PV
     tiam-ucl: Secondary Energy|Electricity|Concentrated Solar PV centralised
@@ -956,6 +956,7 @@ Solar PV Residential:
   iam_aliases:
     gcam: Secondary Energy|Electricity|rooftop_pv
     image: Secondary Energy|Electricity|Solar|PV|2
+    message: Secondary Energy|Electricity|Solar|PV|Residential
     tiam-ucl: Secondary Energy|Electricity|Concentrated Solar PV decentralised
 Storage, Battery:
   ecoinvent_aliases:

--- a/premise/iam_variables_mapping/electricity.yaml
+++ b/premise/iam_variables_mapping/electricity.yaml
@@ -95,14 +95,14 @@ Biomass IGCC:
   eff_aliases:
     gcam: Efficiency|Electricity|biomass (IGCC)
     image: Efficiency|Electricity|Biomass|w/o CCS|2
-    message: Efficiency|Electricity|Biomass|w/o CCS|1
+    message: Efficiency|Electricity|Biomass|Solids|w/o CCS|1
     remind: Tech|Electricity|Biomass|Gasification Combined Cycle w/o CC|Efficiency
     remind-eu: Tech|Electricity|Biomass|Gasification Combined Cycle w/o CC|Efficiency
     tiam-ucl: Efficiency|Electricity|Biomass gasification|w/o CCS
   iam_aliases:
     gcam: Secondary Energy|Electricity|biomass (IGCC)
     image: Secondary Energy|Electricity|Biomass|w/o CCS|2
-    message: Secondary Energy|Electricity|Biomass|w/o CCS|1
+    message: Secondary Energy|Electricity|Biomass|Solids|w/o CCS|1
     remind: SE|Electricity|Biomass|++|Gasification Combined Cycle w/o CC
     remind-eu: SE|Electricity|Biomass|++|Gasification Combined Cycle w/o CC
     tiam-ucl: Secondary Energy|Electricity|Biomass gasification|w/o CCS
@@ -120,7 +120,7 @@ Biomass IGCC CCS:
   eff_aliases:
     gcam: Efficiency|Electricity|biomass (IGCC CCS)
     image: Efficiency|Electricity|Biomass|w/ CCS|1
-    message: Efficiency|Electricity|Biomass|w/o CCS|1
+    message: Efficiency|Electricity|Biomass|Solids|w/o CCS|1
     remind: Tech|Electricity|Biomass|Gasification Combined Cycle w/ CC|Efficiency
     remind-eu: Tech|Electricity|Biomass|Gasification Combined Cycle w/ CC|Efficiency
     tiam-ucl: Efficiency|Electricity|Biomass gasification|w CCS
@@ -128,7 +128,7 @@ Biomass IGCC CCS:
   iam_aliases:
     gcam: Secondary Energy|Electricity|biomass (IGCC CCS)
     image: Secondary Energy|Electricity|Biomass|w/ CCS|1
-    message: Secondary Energy|Electricity|Biomass|w/ CCS|1
+    message: Secondary Energy|Electricity|Biomass|Solids|w/ CCS|1
     remind: SE|Electricity|Biomass|++|Gasification Combined Cycle w/ CC
     remind-eu: SE|Electricity|Biomass|++|Gasification Combined Cycle w/ CC
     tiam-ucl: Secondary Energy|Electricity|Biomass gasification|w CCS
@@ -161,13 +161,13 @@ Biomass ST:
   eff_aliases:
     gcam: Efficiency|Electricity|biomass (conv)
     image: Efficiency|Electricity|Biomass|w/o CCS|1
-    message: Efficiency|Electricity|Biomass|w/o CCS|2
+    message: Efficiency|Electricity|Biomass|Solids|w/o CCS|2
     tiam-ucl: Efficiency|Electricity|Biomass combustion|w/o CCS
 
   iam_aliases:
     gcam: Secondary Energy|Electricity|biomass (conv)
     image: Secondary Energy|Electricity|Biomass|w/o CCS|1
-    message: Secondary Energy|Electricity|Biomass|w/o CCS|2
+    message: Secondary Energy|Electricity|Biomass|Solids|w/o CCS|2
     tiam-ucl: Secondary Energy|Electricity|Biomass combustion|w/o CCS
   max_efficiency: 0.3
 Biomass ST CCS:

--- a/premise/iam_variables_mapping/fuels.yaml
+++ b/premise/iam_variables_mapping/fuels.yaml
@@ -294,7 +294,7 @@ liquid fossil fuels:
     remind: SE|Liquids|Fossil|+|Oil
     remind-eu: SE|Liquids|Fossil|+|Oil
     image: Secondary Energy|Consumption|Liquids|Fossil
-    message: Secondary Energy|Liquids|Oil|Fuel
+    message: Secondary Energy|Liquids|Oil
     witch: Secondary Energy|Liquids|Fossil|Oil
 diesel:
   lhv:
@@ -308,7 +308,7 @@ diesel:
     remind: SE|Liquids|Fossil|+|Oil|Diesel
     remind-eu: SE|Liquids|Fossil|+|Oil|Diesel
     image: Secondary Energy|Consumption|Liquids|Fossil|Diesel
-    message: Secondary Energy|Liquids|Oil|Fuel|Diesel
+    message: Secondary Energy|Liquids|Oil|Light
     witch: Secondary Energy|Liquids|Fossil|Oil|Diesel
   eff_aliases:
     gcam: Efficiency|Refined Liquids|Oil
@@ -346,7 +346,7 @@ gasoline:
     remind: SE|Liquids|Fossil|+|Oil|Gasoline
     remind-eu: SE|Liquids|Fossil|+|Oil|Gasoline
     image: Secondary Energy|Consumption|Liquids|Fossil|Gasoline
-    message: Secondary Energy|Liquids|Oil|Fuel|Gasoline
+    message: Secondary Energy|Liquids|Oil|Light
     witch: Secondary Energy|Liquids|Fossil|Oil|Gasoline
   eff_aliases:
     gcam: Efficiency|Refined Liquids|Oil


### PR DESCRIPTION
This PR adds a mapping of `MESSAGEix-GLOBIOM-GAINS` variables for `Secondary Energy`.

## How to review

1. Read the diff
2. Ensure that changes/additions are self-documenting, i.e. that another developer (someone like the reviewer) will be able to understand what the code does in the future.
