### PR TITLE
Add Sphinx-style documentation to utils helpers

### DIFF
--- a/premise/utils.py
+++ b/premise/utils.py
@@ -228,7 +228,9 @@ def get_efficiency_solar_photovoltaics() -> xr.DataArray:
     return array
 
 
-def default_global_location(database: Iterable[Dict[str, Any]]) -> Iterable[Dict[str, Any]]:
+def default_global_location(
+    database: Iterable[Dict[str, Any]],
+) -> Iterable[Dict[str, Any]]:
     """Ensure that each dataset has a location set.
 
     Missing locations are defaulted to ``"GLO"``.


### PR DESCRIPTION
## Summary
- add Sphinx-style docstrings and argument type hints across `premise.utils`
- document the HiddenPrints context manager and cache helpers to clarify behaviour
- ensure cache metadata loader uses pathlib when accessing cache files

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690c6a6628d883339149df684056e94c