### PR TITLE
Experimental/rss runtime refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project are documented in this file.
 - Improved electricity validation diagnostics by logging dropped electricity shares and missing supplier technologies when market shares do not sum correctly.
 - Normalized the cold-cache `NewDatabase.update()` path so the first scenario reloads the cached source-database representation instead of keeping a special cache-miss in-memory form.
 - Ensured fast Brightway exports set activity process types so exported databases open correctly in downstream Brightway tools such as Activity Browser.
+- Fixed migrated default-inventory placeholders with `replacement ...` metadata so one-to-many ecoinvent migration disaggregations (for example `market for coke` and `market for hard coal` in steel inventories) no longer duplicate the original exchange amount across every split target during gap filling.
 
 ### Documentation
 - Updated the transformation documentation for photovoltaic module efficiency assumptions and added a plot summarizing the trajectories used in `premise`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,16 @@ All notable changes to this project are documented in this file.
 - Expanded GCAM variable coverage across final energy, fuels, electricity, and heat mappings, including additional building, cement, CDR, transport, and biofuel aliases.
 - Updated GCAM regional mapping assets and topology alignment, including explicit `Ukraine` coverage and revised GCAM biofuel/climate region mappings.
 - Reduced cold-cache memory pressure in `NewDatabase()` by extracting Brightway source databases into a more compact in-memory representation and clearing importer-side cached state after inventory imports.
+- Reworked the Brightway 2.5 export path to write processed arrays and database rows directly, substantially reducing `write_db_to_brightway()` runtime and peak memory usage on large scenario exports.
+- Restored standard Brightway database behavior on the fast export path, including searchable activity rows and normal exchange browsing without requiring `import premise` first.
+- Streamed Brightway source-database extraction during cold `NewDatabase()` initialization to avoid queryset caching overhead and reduce cold-start RSS.
 
 ### Fixed
 - Improved IAM normalization for models that do not provide an exact 2020 datapoint by falling back to the nearest available year (notably relevant for GCAM inputs and emissions factors).
 - Moved end-of-pipe emissions updates to the end of the `NewDatabase.update()` workflow to avoid ordering issues (issue `#285`).
 - Improved electricity validation diagnostics by logging dropped electricity shares and missing supplier technologies when market shares do not sum correctly.
 - Normalized the cold-cache `NewDatabase.update()` path so the first scenario reloads the cached source-database representation instead of keeping a special cache-miss in-memory form.
+- Ensured fast Brightway exports set activity process types so exported databases open correctly in downstream Brightway tools such as Activity Browser.
 
 ### Documentation
 - Updated the transformation documentation for photovoltaic module efficiency assumptions and added a plot summarizing the trajectories used in `premise`.

--- a/premise/brightway2.py
+++ b/premise/brightway2.py
@@ -3,10 +3,37 @@ Class to write a Brightway2 database from a Wurst database.
 """
 
 from contextlib import contextmanager
+import pickle
 
 from bw2data import databases
 from bw2io.importers.base_lci import LCIImporter
 from wurst.linking import change_db_name, check_internal_linking, link_internal
+
+
+FAST_ACTIVITY_FIELDS = {
+    "database",
+    "code",
+    "name",
+    "reference product",
+    "unit",
+    "location",
+    "type",
+}
+
+FAST_EXCHANGE_BASE_FIELDS = {
+    "input",
+    "amount",
+    "type",
+}
+
+FAST_EXCHANGE_UNCERTAINTY_FIELDS = {
+    "uncertainty type",
+    "loc",
+    "scale",
+    "shape",
+    "minimum",
+    "maximum",
+}
 
 
 class BW2Importer(LCIImporter):
@@ -46,15 +73,19 @@ def _fast_sqlite_writes(enabled: bool):
 
     original_settings = {}
     original_vacuum = {}
+    original_make_searchable = {}
     original_base_checks = None
     original_substitutable_vacuum = None
+    original_efficient_write_many_data = None
     db_settings = {}
 
     try:
         from bw2data.backends import base as bw_base
+        from bw2data.backends.schema import ActivityDataset, ExchangeDataset
         from bw2data.backends import sqlite3_lci_db as bw_sqlite3_lci_db
         from bw2data import sqlite as bw_sqlite
         from bw2data.configuration import config
+        from bw2data.snowflake_ids import snowflake_id_generator
     except Exception:
         yield
         return
@@ -111,9 +142,15 @@ def _fast_sqlite_writes(enabled: bool):
     def _noop_vacuum(*_args, **_kwargs):
         return None
 
+    def _noop_make_searchable(*_args, **_kwargs):
+        return None
+
     for db in unique_dbs:
         original_vacuum[db] = db.vacuum
         db.vacuum = _noop_vacuum
+        original_make_searchable[db] = getattr(db, "make_searchable", None)
+        if hasattr(db, "make_searchable"):
+            db.make_searchable = _noop_make_searchable
 
     if bw_sqlite is not None and hasattr(bw_sqlite, "SubstitutableDatabase"):
         original_substitutable_vacuum = bw_sqlite.SubstitutableDatabase.vacuum
@@ -133,6 +170,95 @@ def _fast_sqlite_writes(enabled: bool):
     bw_base.check_exchange_keys = _noop_check
     bw_base.check_activity_type = _noop_check
     bw_base.check_activity_keys = _noop_check
+    original_efficient_write_many_data = bw_base.SQLiteBackend._efficient_write_many_data
+
+    def _raw_fast_write_many_data(self, data, indices: bool = True, check_typos: bool = True):
+        be_complicated = len(data) >= 100 and indices
+        if be_complicated:
+            self._drop_indices()
+
+        activity_sql = (
+            f'INSERT INTO "{ActivityDataset._meta.table_name}" '
+            "(id, data, code, database, location, name, product, type) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+        )
+        exchange_sql = (
+            f'INSERT INTO "{ExchangeDataset._meta.table_name}" '
+            "(data, input_code, input_database, output_code, output_database, type) "
+            "VALUES (?, ?, ?, ?, ?, ?)"
+        )
+        activity_batch = []
+        exchange_batch = []
+        activity_batch_size = 250
+        exchange_batch_size = 2_000
+        connection = sqlite3_lci_db.db.connection()
+
+        sqlite3_lci_db.db.autocommit = False
+        try:
+            sqlite3_lci_db.db.begin()
+            self.delete(keep_params=True, warn=False, vacuum=False)
+
+            for ds in bw_base.tqdm_wrapper(data, getattr(config, "is_test", False)):
+                database = ds["database"]
+                code = ds["code"]
+
+                for exchange in ds.get("exchanges", []):
+                    exchange_payload = exchange
+                    if "output" not in exchange_payload:
+                        exchange_payload = {
+                            **exchange,
+                            "output": (database, code),
+                        }
+
+                    exchange_batch.append(
+                        (
+                            pickle.dumps(exchange_payload, protocol=4),
+                            exchange_payload["input"][1],
+                            exchange_payload["input"][0],
+                            exchange_payload["output"][1],
+                            exchange_payload["output"][0],
+                            exchange_payload["type"],
+                        )
+                    )
+
+                    if len(exchange_batch) >= exchange_batch_size:
+                        connection.executemany(exchange_sql, exchange_batch)
+                        exchange_batch = []
+
+                activity_data = {k: v for k, v in ds.items() if k != "exchanges"}
+                activity_batch.append(
+                    (
+                        next(snowflake_id_generator),
+                        pickle.dumps(activity_data, protocol=4),
+                        code,
+                        database,
+                        activity_data.get("location"),
+                        activity_data.get("name"),
+                        activity_data.get("reference product"),
+                        activity_data.get("type"),
+                    )
+                )
+
+                if len(activity_batch) >= activity_batch_size:
+                    connection.executemany(activity_sql, activity_batch)
+                    activity_batch = []
+
+            if activity_batch:
+                connection.executemany(activity_sql, activity_batch)
+            if exchange_batch:
+                connection.executemany(exchange_sql, exchange_batch)
+
+            sqlite3_lci_db.db.commit()
+            sqlite3_lci_db.vacuum()
+        except Exception:
+            sqlite3_lci_db.db.rollback()
+            raise
+        finally:
+            sqlite3_lci_db.db.autocommit = True
+            if be_complicated:
+                self._add_indices()
+
+    bw_base.SQLiteBackend._efficient_write_many_data = _raw_fast_write_many_data
 
     try:
         yield
@@ -140,6 +266,9 @@ def _fast_sqlite_writes(enabled: bool):
         try:
             for db, vacuum_func in original_vacuum.items():
                 db.vacuum = vacuum_func
+            for db, make_searchable_func in original_make_searchable.items():
+                if make_searchable_func is not None:
+                    db.make_searchable = make_searchable_func
             if original_substitutable_vacuum is not None:
                 bw_sqlite.SubstitutableDatabase.vacuum = original_substitutable_vacuum
 
@@ -147,6 +276,10 @@ def _fast_sqlite_writes(enabled: bool):
                 db.db.execute_sql(f"PRAGMA synchronous = {settings['synchronous']};")
                 db.db.execute_sql(f"PRAGMA journal_mode = {settings['journal_mode']};")
                 db.db.execute_sql(f"PRAGMA temp_store = {settings['temp_store']};")
+            if original_efficient_write_many_data is not None:
+                bw_base.SQLiteBackend._efficient_write_many_data = (
+                    original_efficient_write_many_data
+                )
             if original_base_checks is not None:
                 bw_base.check_exchange_type = original_base_checks[
                     "check_exchange_type"
@@ -164,14 +297,66 @@ def _fast_sqlite_writes(enabled: bool):
             pass
 
 
-def write_brightway_database(data: list, name: str, fast: bool = False) -> None:
+def _compact_payload_for_fast_write(data: list) -> list:
+    for dataset in data:
+        exchanges = dataset.get("exchanges", [])
+        compact_dataset = {
+            field: value
+            for field, value in dataset.items()
+            if field in FAST_ACTIVITY_FIELDS and value is not None
+        }
+
+        compact_exchanges = []
+        for exchange in exchanges:
+            compact_exchange = {
+                field: value
+                for field, value in exchange.items()
+                if field in FAST_EXCHANGE_BASE_FIELDS and value is not None
+            }
+
+            uncertainty_type = exchange.get("uncertainty type", 0)
+            if uncertainty_type not in (None, 0):
+                compact_exchange["uncertainty type"] = uncertainty_type
+                for field in FAST_EXCHANGE_UNCERTAINTY_FIELDS - {"uncertainty type"}:
+                    value = exchange.get(field)
+                    if value is not None:
+                        compact_exchange[field] = value
+
+            compact_exchanges.append(compact_exchange)
+
+        compact_dataset["exchanges"] = compact_exchanges
+        dataset.clear()
+        dataset.update(compact_dataset)
+
+    return data
+
+
+def write_brightway_database(
+    data: list,
+    name: str,
+    fast: bool = False,
+    check_internal: bool = True,
+) -> None:
     """
     Write a Brightway2 database from a Wurst database.
     """
+    for act in data:
+        act.setdefault("database", name)
+
+    needs_relink = any(
+        "input" not in exchange
+        for dataset in data
+        for exchange in dataset.get("exchanges", [])
+    )
+
     # Restore parameters to Brightway2 format
     # which allows for uncertainty and comments
     change_db_name(data, name)
-    link_internal(data)
-    check_internal_linking(data)
+    if needs_relink:
+        link_internal(data)
+    if check_internal:
+        check_internal_linking(data)
+    if fast:
+        _compact_payload_for_fast_write(data)
     with _fast_sqlite_writes(fast):
         BW2Importer(name, data).write_database()

--- a/premise/brightway2.py
+++ b/premise/brightway2.py
@@ -64,6 +64,10 @@ class BW2Importer(LCIImporter):
         super().write_database()
 
 
+def _print_database_written(name: str) -> None:
+    print(f"Brightway database written: {name}")
+
+
 @contextmanager
 def _fast_sqlite_writes(enabled: bool):
     if not enabled:
@@ -363,3 +367,4 @@ def write_brightway_database(
         _compact_payload_for_fast_write(data)
     with _fast_sqlite_writes(fast):
         BW2Importer(name, data).write_database()
+    _print_database_written(name)

--- a/premise/brightway2.py
+++ b/premise/brightway2.py
@@ -9,7 +9,6 @@ from bw2data import databases
 from bw2io.importers.base_lci import LCIImporter
 from wurst.linking import change_db_name, check_internal_linking, link_internal
 
-
 FAST_ACTIVITY_FIELDS = {
     "database",
     "code",
@@ -170,9 +169,13 @@ def _fast_sqlite_writes(enabled: bool):
     bw_base.check_exchange_keys = _noop_check
     bw_base.check_activity_type = _noop_check
     bw_base.check_activity_keys = _noop_check
-    original_efficient_write_many_data = bw_base.SQLiteBackend._efficient_write_many_data
+    original_efficient_write_many_data = (
+        bw_base.SQLiteBackend._efficient_write_many_data
+    )
 
-    def _raw_fast_write_many_data(self, data, indices: bool = True, check_typos: bool = True):
+    def _raw_fast_write_many_data(
+        self, data, indices: bool = True, check_typos: bool = True
+    ):
         be_complicated = len(data) >= 100 and indices
         if be_complicated:
             self._drop_indices()

--- a/premise/brightway25.py
+++ b/premise/brightway25.py
@@ -4,15 +4,13 @@ This module contains functions to write a Brightway 2.5 database.
 
 from contextlib import contextmanager
 import datetime
-from functools import lru_cache
-import hashlib
 import pickle
-from pathlib import Path
 import shutil
 import warnings
 
 from bw2data import Database, databases
 from bw2io.importers.base_lci import LCIImporter
+from tqdm import tqdm
 from wurst.linking import change_db_name, check_internal_linking, link_internal
 
 FAST_EXCHANGE_REQUIRED_FIELDS = {
@@ -55,86 +53,36 @@ class BW25Importer(LCIImporter):
             act["database"] = self.db_name
 
 
-def _sidecar_bucket(code: str) -> str:
-    return hashlib.blake2b(code.encode("utf-8"), digest_size=1).hexdigest()
+def _progress(iterable=None, *, total=None, desc=None, unit="dataset", leave=False):
+    try:
+        from bw2data.configuration import config
+
+        disable = getattr(config, "is_test", False)
+    except Exception:
+        disable = False
+
+    return tqdm(
+        iterable,
+        total=total,
+        desc=desc,
+        unit=unit,
+        leave=leave,
+        dynamic_ncols=True,
+        disable=disable,
+    )
 
 
-def _ensure_premise_sidecar_exchange_support() -> None:
-    from bw2data.backends import proxies as bw_proxies
+def _cleanup_legacy_fast_export_sidecars(name: str) -> None:
+    """Remove metadata and files left by older experimental sidecar exports."""
 
-    if getattr(bw_proxies, "_premise_sidecar_exchange_support", False):
-        return
+    sidecar_dir = databases[name].get("premise_fast_exchange_sidecar")
+    reverse_sidecar_dir = databases[name].get("premise_fast_reverse_exchange_sidecar")
+    for filepath in (sidecar_dir, reverse_sidecar_dir):
+        if filepath:
+            shutil.rmtree(filepath, ignore_errors=True)
 
-    original_init = bw_proxies.Exchanges.__init__
-    original_iter = bw_proxies.Exchanges.__iter__
-    original_len = bw_proxies.Exchanges.__len__
-    original_filter = bw_proxies.Exchanges.filter
-
-    @lru_cache(maxsize=128)
-    def load_bucket(sidecar_dir: str, bucket: str):
-        bucket_path = Path(sidecar_dir) / f"{bucket}.pickle"
-        if not bucket_path.exists():
-            return {}
-        with open(bucket_path, "rb") as handle:
-            return pickle.load(handle)
-
-    def sidecar_entries(self):
-        if getattr(self, "_premise_has_custom_filters", False):
-            return None
-        metadata = databases.get(self._key[0], {})
-        if getattr(self, "_premise_reverse", False):
-            sidecar_dir = metadata.get("premise_fast_reverse_exchange_sidecar")
-        else:
-            sidecar_dir = metadata.get("premise_fast_exchange_sidecar")
-        if not sidecar_dir:
-            return None
-
-        shard = load_bucket(sidecar_dir, _sidecar_bucket(self._key[1]))
-        entries = shard.get(self._key[1], ())
-        kinds = getattr(self, "_premise_kinds", None)
-        if kinds:
-            entries = [entry for entry in entries if entry.get("type") in kinds]
-        return entries
-
-    def patched_init(self, key, kinds=None, reverse=False):
-        original_init(self, key, kinds=kinds, reverse=reverse)
-        self._premise_reverse = reverse
-        self._premise_kinds = tuple(kinds) if kinds else None
-        self._premise_has_custom_filters = False
-
-    def patched_filter(self, expr):
-        self._premise_has_custom_filters = True
-        return original_filter(self, expr)
-
-    def patched_iter(self):
-        entries = sidecar_entries(self)
-        if entries is None:
-            yield from original_iter(self)
-            return
-
-        for entry in entries:
-            payload = dict(entry)
-            if getattr(self, "_premise_reverse", False):
-                payload["input"] = self._key
-            else:
-                payload["output"] = self._key
-            yield bw_proxies.Exchange(**payload)
-
-    def patched_len(self):
-        entries = sidecar_entries(self)
-        if entries is None:
-            return original_len(self)
-        return len(entries)
-
-    bw_proxies.Exchanges.__init__ = patched_init
-    bw_proxies.Exchanges.filter = patched_filter
-    bw_proxies.Exchanges.__iter__ = patched_iter
-    bw_proxies.Exchanges.__len__ = patched_len
-    bw_proxies.Exchanges._premise_sidecar_exchange_support = True
-    bw_proxies._premise_sidecar_load_bucket = load_bucket
-
-
-_ensure_premise_sidecar_exchange_support()
+    databases[name].pop("premise_fast_exchange_sidecar", None)
+    databases[name].pop("premise_fast_reverse_exchange_sidecar", None)
 
 
 @contextmanager
@@ -143,7 +91,6 @@ def _fast_sqlite_writes(enabled: bool):
         yield
         return
 
-    original_settings = {}
     original_vacuum = {}
     original_make_searchable = {}
     original_base_checks = None
@@ -183,20 +130,6 @@ def _fast_sqlite_writes(enabled: bool):
     if not unique_dbs:
         yield
         return
-
-    try:
-        primary_db = unique_dbs[0].db
-        original_settings["synchronous"] = primary_db.execute_sql(
-            "PRAGMA synchronous;"
-        ).fetchone()[0]
-        original_settings["journal_mode"] = primary_db.execute_sql(
-            "PRAGMA journal_mode;"
-        ).fetchone()[0]
-        original_settings["temp_store"] = primary_db.execute_sql(
-            "PRAGMA temp_store;"
-        ).fetchone()[0]
-    except Exception:
-        original_settings = {}
 
     try:
         for db in unique_dbs:
@@ -373,7 +306,7 @@ def _fast_sqlite_writes(enabled: bool):
             pass
 
 
-def _compact_payload_for_fast_write(data: list) -> list:
+def _compact_payload_for_fast_write(data: list, name: str) -> list:
     from bw2data.utils import set_correct_process_type
 
     def keep_value(value):
@@ -383,85 +316,46 @@ def _compact_payload_for_fast_write(data: list) -> list:
             return False
         return True
 
-    for dataset in data:
-        set_correct_process_type(dataset)
-        exchanges = dataset.get("exchanges", [])
-        compact_dataset = {
-            field: value
-            for field, value in dataset.items()
-            if field != "exchanges" and keep_value(value)
-        }
-
-        compact_exchanges = []
-        for exchange in exchanges:
-            compact_exchange = {
+    progress = _progress(
+        total=len(data),
+        desc=f"Compacting export payload [{name}]",
+        unit="dataset",
+        leave=False,
+    )
+    try:
+        for dataset in data:
+            set_correct_process_type(dataset)
+            exchanges = dataset.get("exchanges", [])
+            compact_dataset = {
                 field: value
-                for field, value in exchange.items()
-                if field in FAST_EXCHANGE_STORED_FIELDS and keep_value(value)
+                for field, value in dataset.items()
+                if field != "exchanges" and keep_value(value)
             }
-            for field in FAST_EXCHANGE_REQUIRED_FIELDS:
-                if field not in compact_exchange and field in exchange:
-                    compact_exchange[field] = exchange[field]
 
-            compact_exchanges.append(compact_exchange)
+            compact_exchanges = []
+            for exchange in exchanges:
+                compact_exchange = {
+                    field: value
+                    for field, value in exchange.items()
+                    if field in FAST_EXCHANGE_STORED_FIELDS and keep_value(value)
+                }
+                for field in FAST_EXCHANGE_REQUIRED_FIELDS:
+                    if field not in compact_exchange and field in exchange:
+                        compact_exchange[field] = exchange[field]
 
-        compact_dataset["exchanges"] = compact_exchanges
-        dataset.clear()
-        dataset.update(compact_dataset)
+                compact_exchanges.append(compact_exchange)
+
+            compact_dataset["exchanges"] = compact_exchanges
+            dataset.clear()
+            dataset.update(compact_dataset)
+            progress.update(1)
+    finally:
+        progress.close()
 
     return data
 
 
-def _write_exchange_sidecar(
-    data: list, forward_sidecar_dir: Path, reverse_sidecar_dir: Path
-) -> None:
-    for sidecar_dir in (forward_sidecar_dir, reverse_sidecar_dir):
-        if sidecar_dir.exists():
-            shutil.rmtree(sidecar_dir)
-        sidecar_dir.mkdir(parents=True, exist_ok=True)
-
-    forward_buckets = {}
-    reverse_buckets = {}
-    for dataset in data:
-        dataset_key = (dataset["database"], dataset["code"])
-        bucket = _sidecar_bucket(dataset["code"])
-        forward_buckets.setdefault(bucket, {})[dataset["code"]] = dataset.get(
-            "exchanges", []
-        )
-
-        for exchange in dataset.get("exchanges", []):
-            input_key = exchange.get("input")
-            if not input_key or input_key[0] != dataset["database"]:
-                continue
-            if input_key == dataset_key:
-                continue
-
-            reverse_bucket = _sidecar_bucket(input_key[1])
-            reverse_buckets.setdefault(reverse_bucket, {}).setdefault(
-                input_key[1], []
-            ).append(
-                {key: value for key, value in exchange.items() if key != "input"}
-                | {
-                    "output": dataset_key,
-                }
-            )
-
-    for sidecar_dir, buckets in (
-        (forward_sidecar_dir, forward_buckets),
-        (reverse_sidecar_dir, reverse_buckets),
-    ):
-        for bucket, payload in buckets.items():
-            with open(sidecar_dir / f"{bucket}.pickle", "wb") as handle:
-                pickle.dump(payload, handle, protocol=4)
-
-    from bw2data.backends import proxies as bw_proxies
-
-    cache = getattr(bw_proxies, "_premise_sidecar_load_bucket", None)
-    if cache is not None:
-        cache.cache_clear()
-
-
-def _write_search_index_fast(database_filename: str, data: list) -> None:
+def _write_search_index_fast(database_filename: str, data: list, name: str) -> None:
     from bw2data.search.indices import IndexManager
     from bw2data.search.schema import BW2Schema
 
@@ -493,13 +387,23 @@ def _write_search_index_fast(database_filename: str, data: list) -> None:
     batch = []
     batch_size = 2_000
     with index.db.bind_ctx((BW2Schema,)):
-        for dataset in data:
-            batch.append(format_dataset(dataset))
-            if len(batch) >= batch_size:
+        progress = _progress(
+            total=len(data),
+            desc=f"Building search index [{name}]",
+            unit="dataset",
+            leave=False,
+        )
+        try:
+            for dataset in data:
+                batch.append(format_dataset(dataset))
+                if len(batch) >= batch_size:
+                    BW2Schema.insert_many(batch).execute()
+                    batch = []
+                progress.update(1)
+            if batch:
                 BW2Schema.insert_many(batch).execute()
-                batch = []
-        if batch:
-            BW2Schema.insert_many(batch).execute()
+        finally:
+            progress.close()
     index.close()
 
 
@@ -515,14 +419,7 @@ def _write_processed_database_fast(data: list, name: str) -> None:
 
     db = Database(name)
     if name in databases:
-        sidecar_dir = databases[name].get("premise_fast_exchange_sidecar")
-        reverse_sidecar_dir = databases[name].get(
-            "premise_fast_reverse_exchange_sidecar"
-        )
-        if sidecar_dir:
-            shutil.rmtree(sidecar_dir, ignore_errors=True)
-        if reverse_sidecar_dir:
-            shutil.rmtree(reverse_sidecar_dir, ignore_errors=True)
+        _cleanup_legacy_fast_export_sidecars(name)
         db.delete(warn=False, vacuum=False)
         del databases[name]
         db = Database(name)
@@ -546,8 +443,7 @@ def _write_processed_database_fast(data: list, name: str) -> None:
         geocollections.discard(None)
     databases[name]["geocollections"] = sorted(geocollections)
     geomapping.add({dataset["location"] for dataset in data if dataset.get("location")})
-    databases[name].pop("premise_fast_exchange_sidecar", None)
-    databases[name].pop("premise_fast_reverse_exchange_sidecar", None)
+    _cleanup_legacy_fast_export_sidecars(name)
 
     activity_sql = (
         f'INSERT INTO "{ActivityDataset._meta.table_name}" '
@@ -565,8 +461,15 @@ def _write_processed_database_fast(data: list, name: str) -> None:
     exchange_row_batch_size = 5_000
     activity_ids = {}
     connection = sqlite3_lci_db.db.connection()
+    total_datasets = len(data)
 
     sqlite3_lci_db.db.autocommit = False
+    row_progress = _progress(
+        total=total_datasets,
+        desc=f"Writing Brightway rows [{name}]",
+        unit="dataset",
+        leave=False,
+    )
     try:
         sqlite3_lci_db.db.begin()
         for dataset in data:
@@ -620,6 +523,7 @@ def _write_processed_database_fast(data: list, name: str) -> None:
             if len(activity_rows) >= activity_row_batch_size:
                 connection.executemany(activity_sql, activity_rows)
                 activity_rows = []
+            row_progress.update(1)
 
         if activity_rows:
             connection.executemany(activity_sql, activity_rows)
@@ -632,6 +536,7 @@ def _write_processed_database_fast(data: list, name: str) -> None:
         raise
     finally:
         sqlite3_lci_db.db.autocommit = True
+        row_progress.close()
 
     activity_ids = {
         (name, code): activity_id
@@ -661,60 +566,119 @@ def _write_processed_database_fast(data: list, name: str) -> None:
             input_id_cache[input_key] = get_id(input_key)
         return input_id_cache[input_key]
 
+    process_dataset_total = sum(
+        1 for dataset in data if dataset.get("type") in labels.process_node_types
+    )
+
+    def iter_geomapping():
+        progress = _progress(
+            total=process_dataset_total,
+            desc=f"Serializing geomapping [{name}]",
+            unit="dataset",
+            leave=False,
+        )
+        try:
+            for dataset in data:
+                if dataset.get("type") not in labels.process_node_types:
+                    continue
+                progress.update(1)
+                yield {
+                    "row": activity_ids[(name, dataset["code"])],
+                    "col": geomapping[
+                        dataset.get("location") or config.global_location
+                    ],
+                    "amount": 1,
+                }
+        finally:
+            progress.close()
+
     datapackage.add_persistent_vector_from_iterator(
         matrix="inv_geomapping_matrix",
         name=clean_datapackage_name(name + " inventory geomapping matrix"),
-        dict_iterator=(
-            {
-                "row": activity_ids[(name, dataset["code"])],
-                "col": geomapping[dataset.get("location") or config.global_location],
-                "amount": 1,
-            }
-            for dataset in data
-            if dataset.get("type") in labels.process_node_types
-        ),
+        dict_iterator=iter_geomapping(),
     )
 
     def iter_biosphere():
-        for dataset in data:
-            col = activity_ids[(name, dataset["code"])]
-            for exchange in dataset.get("exchanges", []):
-                if exchange["type"] not in labels.biosphere_edge_types:
-                    continue
-                input_key = exchange.get("input")
-                if input_key is None:
-                    raise KeyError(
-                        f"Missing biosphere input for exchange in dataset {dataset['name']!r}."
-                    )
-                if input_key[0] != name:
-                    dependents.add(input_key[0])
-                yield {
-                    **as_uncertainty_dict(exchange),
-                    "row": resolve_input_id(input_key),
-                    "col": col,
-                }
+        progress = _progress(
+            total=total_datasets,
+            desc=f"Serializing biosphere matrix [{name}]",
+            unit="dataset",
+            leave=False,
+        )
+        try:
+            for dataset in data:
+                col = activity_ids[(name, dataset["code"])]
+                for exchange in dataset.get("exchanges", []):
+                    if exchange["type"] not in labels.biosphere_edge_types:
+                        continue
+                    input_key = exchange.get("input")
+                    if input_key is None:
+                        raise KeyError(
+                            f"Missing biosphere input for exchange in dataset {dataset['name']!r}."
+                        )
+                    if input_key[0] != name:
+                        dependents.add(input_key[0])
+                    yield {
+                        **as_uncertainty_dict(exchange),
+                        "row": resolve_input_id(input_key),
+                        "col": col,
+                    }
+                progress.update(1)
+        finally:
+            progress.close()
 
-    def iter_technosphere(edge_types, flip=False):
-        for dataset in data:
-            col = activity_ids[(name, dataset["code"])]
-            for exchange in dataset.get("exchanges", []):
-                if exchange["type"] not in edge_types:
-                    continue
-                input_key = exchange.get("input")
-                if input_key is None:
-                    raise KeyError(
-                        f"Missing technosphere input for exchange in dataset {dataset['name']!r}."
-                    )
-                if input_key[0] != name:
-                    dependents.add(input_key[0])
-                payload = {
-                    **as_uncertainty_dict(exchange),
-                    "row": resolve_input_id(input_key),
-                    "col": col,
-                }
-                if flip:
-                    payload["flip"] = True
-                yield payload
+    negative_edge_types = set(labels.technosphere_negative_edge_types)
+    positive_edge_types = set(labels.technosphere_positive_edge_types)
+
+    def iter_technosphere():
+        progress = _progress(
+            total=total_datasets,
+            desc=f"Serializing technosphere matrix [{name}]",
+            unit="dataset",
+            leave=False,
+        )
+        try:
+            for dataset in data:
+                col = activity_ids[(name, dataset["code"])]
+                has_positive_production = False
+                for exchange in dataset.get("exchanges", []):
+                    edge_type = exchange["type"]
+                    if (
+                        edge_type not in negative_edge_types
+                        and edge_type not in positive_edge_types
+                    ):
+                        continue
+                    input_key = exchange.get("input")
+                    if input_key is None:
+                        raise KeyError(
+                            f"Missing technosphere input for exchange in dataset {dataset['name']!r}."
+                        )
+                    if input_key[0] != name:
+                        dependents.add(input_key[0])
+                    payload = {
+                        **as_uncertainty_dict(exchange),
+                        "row": resolve_input_id(input_key),
+                        "col": col,
+                    }
+                    if edge_type in negative_edge_types:
+                        payload["flip"] = True
+                    else:
+                        has_positive_production = True
+                    yield payload
+
+                if (
+                    dataset.get("type") in labels.implicit_production_allowed_node_types
+                    and not has_positive_production
+                ):
+                    yield {
+                        "row": activity_ids[(name, dataset["code"])],
+                        "col": activity_ids[(name, dataset["code"])],
+                        "amount": 1,
+                    }
+
+                progress.update(1)
+        finally:
+            progress.close()
 
     datapackage.add_persistent_vector_from_iterator(
         matrix="biosphere_matrix",
@@ -725,28 +689,7 @@ def _write_processed_database_fast(data: list, name: str) -> None:
     datapackage.add_persistent_vector_from_iterator(
         matrix="technosphere_matrix",
         name=clean_datapackage_name(name + " technosphere matrix"),
-        dict_iterator=(
-            payload
-            for iterator in (
-                iter_technosphere(labels.technosphere_negative_edge_types, flip=True),
-                iter_technosphere(labels.technosphere_positive_edge_types),
-                (
-                    {
-                        "row": activity_ids[(name, dataset["code"])],
-                        "col": activity_ids[(name, dataset["code"])],
-                        "amount": 1,
-                    }
-                    for dataset in data
-                    if dataset.get("type")
-                    in labels.implicit_production_allowed_node_types
-                    and not any(
-                        exchange["type"] in labels.technosphere_positive_edge_types
-                        for exchange in dataset.get("exchanges", [])
-                    )
-                ),
-            )
-            for payload in iterator
-        ),
+        dict_iterator=iter_technosphere(),
     )
 
     datapackage.finalize_serialization()
@@ -755,7 +698,7 @@ def _write_processed_database_fast(data: list, name: str) -> None:
     db._metadata.flush()
     databases[name]["searchable"] = True
     databases.flush(signal=False)
-    _write_search_index_fast(db.filename, data)
+    _write_search_index_fast(db.filename, data, name)
 
 
 def write_brightway_database(
@@ -781,7 +724,7 @@ def write_brightway_database(
     if check_internal:
         check_internal_linking(data)
     if fast:
-        _compact_payload_for_fast_write(data)
+        _compact_payload_for_fast_write(data, name)
         _write_processed_database_fast(data, name)
         return
 

--- a/premise/brightway25.py
+++ b/premise/brightway25.py
@@ -6,7 +6,6 @@ from contextlib import contextmanager
 import datetime
 import pickle
 import shutil
-import warnings
 
 from bw2data import Database, databases
 from bw2io.importers.base_lci import LCIImporter
@@ -83,6 +82,28 @@ def _cleanup_legacy_fast_export_sidecars(name: str) -> None:
 
     databases[name].pop("premise_fast_exchange_sidecar", None)
     databases[name].pop("premise_fast_reverse_exchange_sidecar", None)
+
+
+def _collect_fast_export_geography(
+    data: list, process_node_types: tuple | list | set, get_geocollection
+) -> tuple[list, set]:
+    geocollections = sorted(
+        {
+            geocollection
+            for geocollection in (
+                get_geocollection(dataset.get("location"))
+                for dataset in data
+                if dataset.get("type") in process_node_types
+            )
+            if geocollection is not None
+        }
+    )
+    locations = {dataset["location"] for dataset in data if dataset.get("location")}
+    return geocollections, locations
+
+
+def _print_database_written(name: str) -> None:
+    print(f"Brightway database written: {name}")
 
 
 @contextmanager
@@ -430,19 +451,13 @@ def _write_processed_database_fast(data: list, name: str) -> None:
     databases[name]["number"] = len(data)
     databases.set_modified(name)
 
-    geocollections = {
-        get_geocollection(dataset.get("location"))
-        for dataset in data
-        if dataset.get("type") in labels.process_node_types
-    }
-    if None in geocollections:
-        warnings.warn(
-            "Not able to determine geocollections for all datasets. "
-            "This database is not ready for regionalization."
-        )
-        geocollections.discard(None)
-    databases[name]["geocollections"] = sorted(geocollections)
-    geomapping.add({dataset["location"] for dataset in data if dataset.get("location")})
+    geocollections, locations = _collect_fast_export_geography(
+        data=data,
+        process_node_types=labels.process_node_types,
+        get_geocollection=get_geocollection,
+    )
+    databases[name]["geocollections"] = geocollections
+    geomapping.add(locations)
     _cleanup_legacy_fast_export_sidecars(name)
 
     activity_sql = (
@@ -726,6 +741,7 @@ def write_brightway_database(
     if fast:
         _compact_payload_for_fast_write(data, name)
         _write_processed_database_fast(data, name)
+        _print_database_written(name)
         return
 
     if name in databases:
@@ -734,3 +750,4 @@ def write_brightway_database(
 
     with _fast_sqlite_writes(fast):
         BW25Importer(name, data).write_database()
+    _print_database_written(name)

--- a/premise/brightway25.py
+++ b/premise/brightway25.py
@@ -15,7 +15,6 @@ from bw2data import Database, databases
 from bw2io.importers.base_lci import LCIImporter
 from wurst.linking import change_db_name, check_internal_linking, link_internal
 
-
 FAST_EXCHANGE_REQUIRED_FIELDS = {
     "input",
     "amount",
@@ -32,7 +31,9 @@ FAST_EXCHANGE_OPTIONAL_FIELDS = {
     "production volume",
 }
 
-FAST_EXCHANGE_STORED_FIELDS = FAST_EXCHANGE_REQUIRED_FIELDS | FAST_EXCHANGE_OPTIONAL_FIELDS
+FAST_EXCHANGE_STORED_FIELDS = (
+    FAST_EXCHANGE_REQUIRED_FIELDS | FAST_EXCHANGE_OPTIONAL_FIELDS
+)
 
 
 class BW25Importer(LCIImporter):
@@ -241,9 +242,13 @@ def _fast_sqlite_writes(enabled: bool):
     bw_base.check_exchange_keys = _noop_check
     bw_base.check_activity_type = _noop_check
     bw_base.check_activity_keys = _noop_check
-    original_efficient_write_many_data = bw_base.SQLiteBackend._efficient_write_many_data
+    original_efficient_write_many_data = (
+        bw_base.SQLiteBackend._efficient_write_many_data
+    )
 
-    def _raw_fast_write_many_data(self, data, indices: bool = True, check_typos: bool = True):
+    def _raw_fast_write_many_data(
+        self, data, indices: bool = True, check_typos: bool = True
+    ):
         be_complicated = len(data) >= 100 and indices
         if be_complicated:
             self._drop_indices()
@@ -435,11 +440,7 @@ def _write_exchange_sidecar(
             reverse_buckets.setdefault(reverse_bucket, {}).setdefault(
                 input_key[1], []
             ).append(
-                {
-                    key: value
-                    for key, value in exchange.items()
-                    if key != "input"
-                }
+                {key: value for key, value in exchange.items() if key != "input"}
                 | {
                     "output": dataset_key,
                 }
@@ -515,7 +516,9 @@ def _write_processed_database_fast(data: list, name: str) -> None:
     db = Database(name)
     if name in databases:
         sidecar_dir = databases[name].get("premise_fast_exchange_sidecar")
-        reverse_sidecar_dir = databases[name].get("premise_fast_reverse_exchange_sidecar")
+        reverse_sidecar_dir = databases[name].get(
+            "premise_fast_reverse_exchange_sidecar"
+        )
         if sidecar_dir:
             shutil.rmtree(sidecar_dir, ignore_errors=True)
         if reverse_sidecar_dir:
@@ -570,7 +573,11 @@ def _write_processed_database_fast(data: list, name: str) -> None:
             activity_rows.append(
                 (
                     pickle.dumps(
-                        {key: value for key, value in dataset.items() if key != "exchanges"},
+                        {
+                            key: value
+                            for key, value in dataset.items()
+                            if key != "exchanges"
+                        },
                         protocol=4,
                     ),
                     dataset["code"],

--- a/premise/brightway25.py
+++ b/premise/brightway25.py
@@ -3,10 +3,36 @@ This module contains functions to write a Brightway 2.5 database.
 """
 
 from contextlib import contextmanager
+import datetime
+from functools import lru_cache
+import hashlib
+import pickle
+from pathlib import Path
+import shutil
+import warnings
 
 from bw2data import Database, databases
 from bw2io.importers.base_lci import LCIImporter
 from wurst.linking import change_db_name, check_internal_linking, link_internal
+
+
+FAST_EXCHANGE_REQUIRED_FIELDS = {
+    "input",
+    "amount",
+    "type",
+}
+
+FAST_EXCHANGE_OPTIONAL_FIELDS = {
+    "uncertainty type",
+    "loc",
+    "scale",
+    "shape",
+    "minimum",
+    "maximum",
+    "production volume",
+}
+
+FAST_EXCHANGE_STORED_FIELDS = FAST_EXCHANGE_REQUIRED_FIELDS | FAST_EXCHANGE_OPTIONAL_FIELDS
 
 
 class BW25Importer(LCIImporter):
@@ -28,6 +54,88 @@ class BW25Importer(LCIImporter):
             act["database"] = self.db_name
 
 
+def _sidecar_bucket(code: str) -> str:
+    return hashlib.blake2b(code.encode("utf-8"), digest_size=1).hexdigest()
+
+
+def _ensure_premise_sidecar_exchange_support() -> None:
+    from bw2data.backends import proxies as bw_proxies
+
+    if getattr(bw_proxies, "_premise_sidecar_exchange_support", False):
+        return
+
+    original_init = bw_proxies.Exchanges.__init__
+    original_iter = bw_proxies.Exchanges.__iter__
+    original_len = bw_proxies.Exchanges.__len__
+    original_filter = bw_proxies.Exchanges.filter
+
+    @lru_cache(maxsize=128)
+    def load_bucket(sidecar_dir: str, bucket: str):
+        bucket_path = Path(sidecar_dir) / f"{bucket}.pickle"
+        if not bucket_path.exists():
+            return {}
+        with open(bucket_path, "rb") as handle:
+            return pickle.load(handle)
+
+    def sidecar_entries(self):
+        if getattr(self, "_premise_has_custom_filters", False):
+            return None
+        metadata = databases.get(self._key[0], {})
+        if getattr(self, "_premise_reverse", False):
+            sidecar_dir = metadata.get("premise_fast_reverse_exchange_sidecar")
+        else:
+            sidecar_dir = metadata.get("premise_fast_exchange_sidecar")
+        if not sidecar_dir:
+            return None
+
+        shard = load_bucket(sidecar_dir, _sidecar_bucket(self._key[1]))
+        entries = shard.get(self._key[1], ())
+        kinds = getattr(self, "_premise_kinds", None)
+        if kinds:
+            entries = [entry for entry in entries if entry.get("type") in kinds]
+        return entries
+
+    def patched_init(self, key, kinds=None, reverse=False):
+        original_init(self, key, kinds=kinds, reverse=reverse)
+        self._premise_reverse = reverse
+        self._premise_kinds = tuple(kinds) if kinds else None
+        self._premise_has_custom_filters = False
+
+    def patched_filter(self, expr):
+        self._premise_has_custom_filters = True
+        return original_filter(self, expr)
+
+    def patched_iter(self):
+        entries = sidecar_entries(self)
+        if entries is None:
+            yield from original_iter(self)
+            return
+
+        for entry in entries:
+            payload = dict(entry)
+            if getattr(self, "_premise_reverse", False):
+                payload["input"] = self._key
+            else:
+                payload["output"] = self._key
+            yield bw_proxies.Exchange(**payload)
+
+    def patched_len(self):
+        entries = sidecar_entries(self)
+        if entries is None:
+            return original_len(self)
+        return len(entries)
+
+    bw_proxies.Exchanges.__init__ = patched_init
+    bw_proxies.Exchanges.filter = patched_filter
+    bw_proxies.Exchanges.__iter__ = patched_iter
+    bw_proxies.Exchanges.__len__ = patched_len
+    bw_proxies.Exchanges._premise_sidecar_exchange_support = True
+    bw_proxies._premise_sidecar_load_bucket = load_bucket
+
+
+_ensure_premise_sidecar_exchange_support()
+
+
 @contextmanager
 def _fast_sqlite_writes(enabled: bool):
     if not enabled:
@@ -36,15 +144,19 @@ def _fast_sqlite_writes(enabled: bool):
 
     original_settings = {}
     original_vacuum = {}
+    original_make_searchable = {}
     original_base_checks = None
     original_substitutable_vacuum = None
+    original_efficient_write_many_data = None
     db_settings = {}
 
     try:
         from bw2data.backends import base as bw_base
+        from bw2data.backends.schema import ActivityDataset, ExchangeDataset
         from bw2data.backends import sqlite3_lci_db as bw_sqlite3_lci_db
         from bw2data import sqlite as bw_sqlite
         from bw2data.configuration import config
+        from bw2data.snowflake_ids import snowflake_id_generator
     except Exception:
         yield
         return
@@ -101,9 +213,15 @@ def _fast_sqlite_writes(enabled: bool):
     def _noop_vacuum(*_args, **_kwargs):
         return None
 
+    def _noop_make_searchable(*_args, **_kwargs):
+        return None
+
     for db in unique_dbs:
         original_vacuum[db] = db.vacuum
         db.vacuum = _noop_vacuum
+        original_make_searchable[db] = getattr(db, "make_searchable", None)
+        if hasattr(db, "make_searchable"):
+            db.make_searchable = _noop_make_searchable
 
     if bw_sqlite is not None and hasattr(bw_sqlite, "SubstitutableDatabase"):
         original_substitutable_vacuum = bw_sqlite.SubstitutableDatabase.vacuum
@@ -123,6 +241,95 @@ def _fast_sqlite_writes(enabled: bool):
     bw_base.check_exchange_keys = _noop_check
     bw_base.check_activity_type = _noop_check
     bw_base.check_activity_keys = _noop_check
+    original_efficient_write_many_data = bw_base.SQLiteBackend._efficient_write_many_data
+
+    def _raw_fast_write_many_data(self, data, indices: bool = True, check_typos: bool = True):
+        be_complicated = len(data) >= 100 and indices
+        if be_complicated:
+            self._drop_indices()
+
+        activity_sql = (
+            f'INSERT INTO "{ActivityDataset._meta.table_name}" '
+            "(id, data, code, database, location, name, product, type) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+        )
+        exchange_sql = (
+            f'INSERT INTO "{ExchangeDataset._meta.table_name}" '
+            "(data, input_code, input_database, output_code, output_database, type) "
+            "VALUES (?, ?, ?, ?, ?, ?)"
+        )
+        activity_batch = []
+        exchange_batch = []
+        activity_batch_size = 250
+        exchange_batch_size = 2_000
+        connection = sqlite3_lci_db.db.connection()
+
+        sqlite3_lci_db.db.autocommit = False
+        try:
+            sqlite3_lci_db.db.begin()
+            self.delete(keep_params=True, warn=False, vacuum=False)
+
+            for ds in bw_base.tqdm_wrapper(data, getattr(config, "is_test", False)):
+                database = ds["database"]
+                code = ds["code"]
+
+                for exchange in ds.get("exchanges", []):
+                    exchange_payload = exchange
+                    if "output" not in exchange_payload:
+                        exchange_payload = {
+                            **exchange,
+                            "output": (database, code),
+                        }
+
+                    exchange_batch.append(
+                        (
+                            pickle.dumps(exchange_payload, protocol=4),
+                            exchange_payload["input"][1],
+                            exchange_payload["input"][0],
+                            exchange_payload["output"][1],
+                            exchange_payload["output"][0],
+                            exchange_payload["type"],
+                        )
+                    )
+
+                    if len(exchange_batch) >= exchange_batch_size:
+                        connection.executemany(exchange_sql, exchange_batch)
+                        exchange_batch = []
+
+                activity_data = {k: v for k, v in ds.items() if k != "exchanges"}
+                activity_batch.append(
+                    (
+                        next(snowflake_id_generator),
+                        pickle.dumps(activity_data, protocol=4),
+                        code,
+                        database,
+                        activity_data.get("location"),
+                        activity_data.get("name"),
+                        activity_data.get("reference product"),
+                        activity_data.get("type"),
+                    )
+                )
+
+                if len(activity_batch) >= activity_batch_size:
+                    connection.executemany(activity_sql, activity_batch)
+                    activity_batch = []
+
+            if activity_batch:
+                connection.executemany(activity_sql, activity_batch)
+            if exchange_batch:
+                connection.executemany(exchange_sql, exchange_batch)
+
+            sqlite3_lci_db.db.commit()
+            sqlite3_lci_db.vacuum()
+        except Exception:
+            sqlite3_lci_db.db.rollback()
+            raise
+        finally:
+            sqlite3_lci_db.db.autocommit = True
+            if be_complicated:
+                self._add_indices()
+
+    bw_base.SQLiteBackend._efficient_write_many_data = _raw_fast_write_many_data
 
     try:
         yield
@@ -130,6 +337,9 @@ def _fast_sqlite_writes(enabled: bool):
         try:
             for db, vacuum_func in original_vacuum.items():
                 db.vacuum = vacuum_func
+            for db, make_searchable_func in original_make_searchable.items():
+                if make_searchable_func is not None:
+                    db.make_searchable = make_searchable_func
             if original_substitutable_vacuum is not None:
                 bw_sqlite.SubstitutableDatabase.vacuum = original_substitutable_vacuum
 
@@ -137,6 +347,10 @@ def _fast_sqlite_writes(enabled: bool):
                 db.db.execute_sql(f"PRAGMA synchronous = {settings['synchronous']};")
                 db.db.execute_sql(f"PRAGMA journal_mode = {settings['journal_mode']};")
                 db.db.execute_sql(f"PRAGMA temp_store = {settings['temp_store']};")
+            if original_efficient_write_many_data is not None:
+                bw_base.SQLiteBackend._efficient_write_many_data = (
+                    original_efficient_write_many_data
+                )
             if original_base_checks is not None:
                 bw_base.check_exchange_type = original_base_checks[
                     "check_exchange_type"
@@ -154,12 +368,412 @@ def _fast_sqlite_writes(enabled: bool):
             pass
 
 
-def write_brightway_database(data: list, name: str, fast: bool = False) -> None:
+def _compact_payload_for_fast_write(data: list) -> list:
+    def keep_value(value):
+        if value is None:
+            return False
+        if isinstance(value, str) and value in {"None", "nan"}:
+            return False
+        return True
+
+    for dataset in data:
+        exchanges = dataset.get("exchanges", [])
+        compact_dataset = {
+            field: value
+            for field, value in dataset.items()
+            if field != "exchanges" and keep_value(value)
+        }
+
+        compact_exchanges = []
+        for exchange in exchanges:
+            compact_exchange = {
+                field: value
+                for field, value in exchange.items()
+                if field in FAST_EXCHANGE_STORED_FIELDS and keep_value(value)
+            }
+            for field in FAST_EXCHANGE_REQUIRED_FIELDS:
+                if field not in compact_exchange and field in exchange:
+                    compact_exchange[field] = exchange[field]
+
+            compact_exchanges.append(compact_exchange)
+
+        compact_dataset["exchanges"] = compact_exchanges
+        dataset.clear()
+        dataset.update(compact_dataset)
+
+    return data
+
+
+def _write_exchange_sidecar(
+    data: list, forward_sidecar_dir: Path, reverse_sidecar_dir: Path
+) -> None:
+    for sidecar_dir in (forward_sidecar_dir, reverse_sidecar_dir):
+        if sidecar_dir.exists():
+            shutil.rmtree(sidecar_dir)
+        sidecar_dir.mkdir(parents=True, exist_ok=True)
+
+    forward_buckets = {}
+    reverse_buckets = {}
+    for dataset in data:
+        dataset_key = (dataset["database"], dataset["code"])
+        bucket = _sidecar_bucket(dataset["code"])
+        forward_buckets.setdefault(bucket, {})[dataset["code"]] = dataset.get(
+            "exchanges", []
+        )
+
+        for exchange in dataset.get("exchanges", []):
+            input_key = exchange.get("input")
+            if not input_key or input_key[0] != dataset["database"]:
+                continue
+            if input_key == dataset_key:
+                continue
+
+            reverse_bucket = _sidecar_bucket(input_key[1])
+            reverse_buckets.setdefault(reverse_bucket, {}).setdefault(
+                input_key[1], []
+            ).append(
+                {
+                    key: value
+                    for key, value in exchange.items()
+                    if key != "input"
+                }
+                | {
+                    "output": dataset_key,
+                }
+            )
+
+    for sidecar_dir, buckets in (
+        (forward_sidecar_dir, forward_buckets),
+        (reverse_sidecar_dir, reverse_buckets),
+    ):
+        for bucket, payload in buckets.items():
+            with open(sidecar_dir / f"{bucket}.pickle", "wb") as handle:
+                pickle.dump(payload, handle, protocol=4)
+
+    from bw2data.backends import proxies as bw_proxies
+
+    cache = getattr(bw_proxies, "_premise_sidecar_load_bucket", None)
+    if cache is not None:
+        cache.cache_clear()
+
+
+def _write_search_index_fast(database_filename: str, data: list) -> None:
+    from bw2data.search.indices import IndexManager
+    from bw2data.search.schema import BW2Schema
+
+    def format_dataset(ds):
+        location = ds.get("location") or ""
+        if isinstance(location, tuple):
+            location = location[1]
+        if isinstance(location, str):
+            if location.lower() == "none":
+                location = ""
+            else:
+                location = location.lower().strip()
+        else:
+            location = ""
+
+        return {
+            "name": (ds.get("name") or "").lower(),
+            "comment": (ds.get("comment") or "").lower(),
+            "product": (ds.get("reference product") or "").lower(),
+            "categories": ", ".join(ds.get("categories") or []).lower(),
+            "synonyms": ", ".join(ds.get("synonyms") or []).lower(),
+            "location": location,
+            "database": ds["database"],
+            "code": ds["code"],
+        }
+
+    index = IndexManager(database_filename)
+    index.create()
+    batch = []
+    batch_size = 2_000
+    with index.db.bind_ctx((BW2Schema,)):
+        for dataset in data:
+            batch.append(format_dataset(dataset))
+            if len(batch) >= batch_size:
+                BW2Schema.insert_many(batch).execute()
+                batch = []
+        if batch:
+            BW2Schema.insert_many(batch).execute()
+    index.close()
+
+
+def _write_processed_database_fast(data: list, name: str) -> None:
+    from bw_processing import clean_datapackage_name, create_datapackage
+    from fsspec.implementations.zip import ZipFileSystem
+
+    from bw2data import geomapping
+    from bw2data.backends import sqlite3_lci_db
+    from bw2data.backends.schema import ActivityDataset, ExchangeDataset, get_id
+    from bw2data.configuration import config, labels
+    from bw2data.utils import as_uncertainty_dict, get_geocollection
+
+    db = Database(name)
+    if name in databases:
+        sidecar_dir = databases[name].get("premise_fast_exchange_sidecar")
+        reverse_sidecar_dir = databases[name].get("premise_fast_reverse_exchange_sidecar")
+        if sidecar_dir:
+            shutil.rmtree(sidecar_dir, ignore_errors=True)
+        if reverse_sidecar_dir:
+            shutil.rmtree(reverse_sidecar_dir, ignore_errors=True)
+        db.delete(warn=False, vacuum=False)
+        del databases[name]
+        db = Database(name)
+
+    if name not in databases:
+        db.register(write_empty=False)
+
+    databases[name]["number"] = len(data)
+    databases.set_modified(name)
+
+    geocollections = {
+        get_geocollection(dataset.get("location"))
+        for dataset in data
+        if dataset.get("type") in labels.process_node_types
+    }
+    if None in geocollections:
+        warnings.warn(
+            "Not able to determine geocollections for all datasets. "
+            "This database is not ready for regionalization."
+        )
+        geocollections.discard(None)
+    databases[name]["geocollections"] = sorted(geocollections)
+    geomapping.add({dataset["location"] for dataset in data if dataset.get("location")})
+    databases[name].pop("premise_fast_exchange_sidecar", None)
+    databases[name].pop("premise_fast_reverse_exchange_sidecar", None)
+
+    activity_sql = (
+        f'INSERT INTO "{ActivityDataset._meta.table_name}" '
+        "(data, code, database, location, name, product, type) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)"
+    )
+    exchange_sql = (
+        f'INSERT INTO "{ExchangeDataset._meta.table_name}" '
+        "(data, input_code, input_database, output_code, output_database, type) "
+        "VALUES (?, ?, ?, ?, ?, ?)"
+    )
+    activity_rows = []
+    exchange_rows = []
+    activity_row_batch_size = 1_000
+    exchange_row_batch_size = 5_000
+    activity_ids = {}
+    connection = sqlite3_lci_db.db.connection()
+
+    sqlite3_lci_db.db.autocommit = False
+    try:
+        sqlite3_lci_db.db.begin()
+        for dataset in data:
+            activity_rows.append(
+                (
+                    pickle.dumps(
+                        {key: value for key, value in dataset.items() if key != "exchanges"},
+                        protocol=4,
+                    ),
+                    dataset["code"],
+                    name,
+                    dataset.get("location"),
+                    dataset.get("name"),
+                    dataset.get("reference product"),
+                    dataset.get("type"),
+                )
+            )
+
+            for exchange in dataset.get("exchanges", []):
+                input_key = exchange.get("input")
+                if input_key is None:
+                    raise KeyError(
+                        f"Missing input for exchange in dataset {dataset['name']!r}."
+                    )
+
+                exchange_rows.append(
+                    (
+                        pickle.dumps(
+                            {
+                                key: value
+                                for key, value in exchange.items()
+                                if key in FAST_EXCHANGE_STORED_FIELDS
+                            },
+                            protocol=4,
+                        ),
+                        input_key[1],
+                        input_key[0],
+                        dataset["code"],
+                        name,
+                        exchange["type"],
+                    )
+                )
+                if len(exchange_rows) >= exchange_row_batch_size:
+                    connection.executemany(exchange_sql, exchange_rows)
+                    exchange_rows = []
+
+            if len(activity_rows) >= activity_row_batch_size:
+                connection.executemany(activity_sql, activity_rows)
+                activity_rows = []
+
+        if activity_rows:
+            connection.executemany(activity_sql, activity_rows)
+        if exchange_rows:
+            connection.executemany(exchange_sql, exchange_rows)
+
+        sqlite3_lci_db.db.commit()
+    except Exception:
+        sqlite3_lci_db.db.rollback()
+        raise
+    finally:
+        sqlite3_lci_db.db.autocommit = True
+
+    activity_ids = {
+        (name, code): activity_id
+        for activity_id, code in ActivityDataset.select(
+            ActivityDataset.id, ActivityDataset.code
+        )
+        .where(ActivityDataset.database == name)
+        .tuples()
+    }
+
+    db.metadata["processed"] = datetime.datetime.now().isoformat()
+    datapackage_path = str(db.dirpath_processed() / db.filename_processed())
+    datapackage = create_datapackage(
+        fs=ZipFileSystem(datapackage_path, mode="w"),
+        name=clean_datapackage_name(name),
+        sum_intra_duplicates=True,
+        sum_inter_duplicates=False,
+    )
+
+    dependents = set()
+    input_id_cache = {}
+
+    def resolve_input_id(input_key):
+        if input_key[0] == name:
+            return activity_ids[input_key]
+        if input_key not in input_id_cache:
+            input_id_cache[input_key] = get_id(input_key)
+        return input_id_cache[input_key]
+
+    datapackage.add_persistent_vector_from_iterator(
+        matrix="inv_geomapping_matrix",
+        name=clean_datapackage_name(name + " inventory geomapping matrix"),
+        dict_iterator=(
+            {
+                "row": activity_ids[(name, dataset["code"])],
+                "col": geomapping[dataset.get("location") or config.global_location],
+                "amount": 1,
+            }
+            for dataset in data
+            if dataset.get("type") in labels.process_node_types
+        ),
+    )
+
+    def iter_biosphere():
+        for dataset in data:
+            col = activity_ids[(name, dataset["code"])]
+            for exchange in dataset.get("exchanges", []):
+                if exchange["type"] not in labels.biosphere_edge_types:
+                    continue
+                input_key = exchange.get("input")
+                if input_key is None:
+                    raise KeyError(
+                        f"Missing biosphere input for exchange in dataset {dataset['name']!r}."
+                    )
+                if input_key[0] != name:
+                    dependents.add(input_key[0])
+                yield {
+                    **as_uncertainty_dict(exchange),
+                    "row": resolve_input_id(input_key),
+                    "col": col,
+                }
+
+    def iter_technosphere(edge_types, flip=False):
+        for dataset in data:
+            col = activity_ids[(name, dataset["code"])]
+            for exchange in dataset.get("exchanges", []):
+                if exchange["type"] not in edge_types:
+                    continue
+                input_key = exchange.get("input")
+                if input_key is None:
+                    raise KeyError(
+                        f"Missing technosphere input for exchange in dataset {dataset['name']!r}."
+                    )
+                if input_key[0] != name:
+                    dependents.add(input_key[0])
+                payload = {
+                    **as_uncertainty_dict(exchange),
+                    "row": resolve_input_id(input_key),
+                    "col": col,
+                }
+                if flip:
+                    payload["flip"] = True
+                yield payload
+
+    datapackage.add_persistent_vector_from_iterator(
+        matrix="biosphere_matrix",
+        name=clean_datapackage_name(name + " biosphere matrix"),
+        dict_iterator=iter_biosphere(),
+    )
+
+    datapackage.add_persistent_vector_from_iterator(
+        matrix="technosphere_matrix",
+        name=clean_datapackage_name(name + " technosphere matrix"),
+        dict_iterator=(
+            payload
+            for iterator in (
+                iter_technosphere(labels.technosphere_negative_edge_types, flip=True),
+                iter_technosphere(labels.technosphere_positive_edge_types),
+                (
+                    {
+                        "row": activity_ids[(name, dataset["code"])],
+                        "col": activity_ids[(name, dataset["code"])],
+                        "amount": 1,
+                    }
+                    for dataset in data
+                    if dataset.get("type")
+                    in labels.implicit_production_allowed_node_types
+                    and not any(
+                        exchange["type"] in labels.technosphere_positive_edge_types
+                        for exchange in dataset.get("exchanges", [])
+                    )
+                ),
+            )
+            for payload in iterator
+        ),
+    )
+
+    datapackage.finalize_serialization()
+    db.metadata["depends"] = sorted(dependents)
+    db.metadata["dirty"] = False
+    db._metadata.flush()
+    databases[name]["searchable"] = True
+    databases.flush(signal=False)
+    _write_search_index_fast(db.filename, data)
+
+
+def write_brightway_database(
+    data: list,
+    name: str,
+    fast: bool = False,
+    check_internal: bool = True,
+) -> None:
+    for act in data:
+        act.setdefault("database", name)
+
+    needs_relink = any(
+        "input" not in exchange
+        for dataset in data
+        for exchange in dataset.get("exchanges", [])
+    )
+
     # Restore parameters to Brightway2 format
     # which allows for uncertainty and comments
     change_db_name(data, name)
-    link_internal(data)
-    check_internal_linking(data)
+    if needs_relink:
+        link_internal(data)
+    if check_internal:
+        check_internal_linking(data)
+    if fast:
+        _compact_payload_for_fast_write(data)
+        _write_processed_database_fast(data, name)
+        return
 
     if name in databases:
         print(f"Database {name} already exists: it will be overwritten.")

--- a/premise/brightway25.py
+++ b/premise/brightway25.py
@@ -106,6 +106,10 @@ def _print_database_written(name: str) -> None:
     print(f"Brightway database written: {name}")
 
 
+def _print_database_overwrite(name: str) -> None:
+    print(f"Database {name} already exists: it will be overwritten.")
+
+
 @contextmanager
 def _fast_sqlite_writes(enabled: bool):
     if not enabled:
@@ -739,13 +743,15 @@ def write_brightway_database(
     if check_internal:
         check_internal_linking(data)
     if fast:
+        if name in databases:
+            _print_database_overwrite(name)
         _compact_payload_for_fast_write(data, name)
         _write_processed_database_fast(data, name)
         _print_database_written(name)
         return
 
     if name in databases:
-        print(f"Database {name} already exists: it will be overwritten.")
+        _print_database_overwrite(name)
         del databases[name]
 
     with _fast_sqlite_writes(fast):

--- a/premise/brightway25.py
+++ b/premise/brightway25.py
@@ -369,6 +369,8 @@ def _fast_sqlite_writes(enabled: bool):
 
 
 def _compact_payload_for_fast_write(data: list) -> list:
+    from bw2data.utils import set_correct_process_type
+
     def keep_value(value):
         if value is None:
             return False
@@ -377,6 +379,7 @@ def _compact_payload_for_fast_write(data: list) -> list:
         return True
 
     for dataset in data:
+        set_correct_process_type(dataset)
         exchanges = dataset.get("exchanges", [])
         compact_dataset = {
             field: value

--- a/premise/clean_datasets.py
+++ b/premise/clean_datasets.py
@@ -283,12 +283,13 @@ def _extract_exchange_for_premise(
 def _add_exchanges_to_consumers_for_premise(
     activities: List[Dict[str, Any]],
     exchange_qs,
+    exchange_count: Optional[int] = None,
     add_properties: bool = False,
 ) -> List[Dict[str, Any]]:
     lookup = {(o["database"], o["code"]): o for o in activities}
 
-    with tqdm(total=exchange_qs.count()) as pbar:
-        for exc_proxy in exchange_qs:
+    with tqdm(total=exchange_count) as pbar:
+        for exc_proxy in exchange_qs.iterator():
             exc = _extract_exchange_for_premise(
                 exc_proxy, add_properties=add_properties
             )
@@ -383,16 +384,21 @@ def extract_brightway_databases_for_premise(
     exchange_qs = ExchangeDataset.select().where(
         ExchangeDataset.output_database << database_names
     )
+    activity_count = activity_qs.count()
+    exchange_count = exchange_qs.count()
 
     print("Getting activity data")
     activities = [
         _extract_activity_for_premise(o, add_identifiers=add_identifiers)
-        for o in tqdm(activity_qs)
+        for o in tqdm(activity_qs.iterator(), total=activity_count)
     ]
 
     print("Adding exchange data to activities")
     _add_exchanges_to_consumers_for_premise(
-        activities, exchange_qs, add_properties=add_properties
+        activities,
+        exchange_qs,
+        exchange_count=exchange_count,
+        add_properties=add_properties,
     )
 
     print("Filling out exchange data")

--- a/premise/export.py
+++ b/premise/export.py
@@ -1179,7 +1179,7 @@ def prepare_db_for_export(
 def prepare_db_for_fast_export(scenario, name, version, biosphere_name=None):
     """
     Prepare a database for Brightway export using only the minimal
-    formatting and linking steps required by the writer.
+    formatting and validation steps required by the fast writer.
     """
 
     validator = BaseDatasetValidator(
@@ -1193,11 +1193,7 @@ def prepare_db_for_fast_export(scenario, name, version, biosphere_name=None):
         biosphere_name=biosphere_name,
         version=version,
     )
-    validator.remove_unused_fields()
-    validator.correct_fields_format()
-    validator.check_amount_format()
-    validator.reformat_parameters()
-    validator.check_database_name()
+    validator.run_fast_export_checks()
 
     return validator.database
 

--- a/premise/export.py
+++ b/premise/export.py
@@ -1176,6 +1176,32 @@ def prepare_db_for_export(
     return validator.database
 
 
+def prepare_db_for_fast_export(scenario, name, version, biosphere_name=None):
+    """
+    Prepare a database for Brightway export using only the minimal
+    formatting and linking steps required by the writer.
+    """
+
+    validator = BaseDatasetValidator(
+        model=scenario["model"],
+        scenario=scenario["pathway"],
+        year=scenario["year"],
+        regions=scenario["iam data"].regions,
+        original_database=[],
+        database=scenario["database"],
+        db_name=name,
+        biosphere_name=biosphere_name,
+        version=version,
+    )
+    validator.remove_unused_fields()
+    validator.correct_fields_format()
+    validator.check_amount_format()
+    validator.reformat_parameters()
+    validator.check_database_name()
+
+    return validator.database
+
+
 def _prepare_database(scenario, db_name, original_database, biosphere_name, version):
 
     scenario["database"] = prepare_db_for_export(

--- a/premise/inventory_imports.py
+++ b/premise/inventory_imports.py
@@ -1300,9 +1300,7 @@ class BaseInventoryImport:
                             )
                             return
 
-                        for e in self._find_matching_technosphere_exchanges(
-                            ds, n, exc
-                        ):
+                        for e in self._find_matching_technosphere_exchanges(ds, n, exc):
                             sum_amount += e["amount"]
 
                         if sum_amount == 0:

--- a/premise/inventory_imports.py
+++ b/premise/inventory_imports.py
@@ -1076,6 +1076,177 @@ class BaseInventoryImport:
                 )
             ]
 
+    @staticmethod
+    def _replacement_metadata(exc: dict) -> tuple[str, str, str]:
+        return (
+            exc["replacement name"],
+            exc["replacement product"],
+            exc["replacement location"],
+        )
+
+    def _find_replacement_dataset(self, exc: dict) -> dict | None:
+        name, ref_prod, loc = self._replacement_metadata(exc)
+
+        for ds in self.database:
+            if (
+                ds["name"] == name
+                and ds["reference product"] == ref_prod
+                and ds["location"] == loc
+            ):
+                return ds
+
+        return None
+
+    @staticmethod
+    def _toggle_market_name(name: str) -> str | None:
+        if "market for" in name:
+            return name.replace("market for", "market group for")
+        if "market group for" in name:
+            return name.replace("market group for", "market for")
+        return None
+
+    @staticmethod
+    def _find_matching_technosphere_exchanges(
+        dataset: dict, exchange_name: str, exc: dict
+    ) -> List[dict]:
+        """
+        Return matching technosphere exchanges from ``dataset`` for ``exc``.
+
+        Prefer exact supplier-location matches when available so we don't
+        accidentally sum several regional suppliers from the replacement dataset.
+        """
+
+        matches = list(
+            ws.technosphere(
+                dataset,
+                ws.equals("name", exchange_name),
+                ws.equals("product", exc["product"]),
+            )
+        )
+
+        if not matches:
+            return matches
+
+        if "location" not in exc:
+            return matches
+
+        exact_location_matches = [
+            match for match in matches if match.get("location") == exc["location"]
+        ]
+
+        if exact_location_matches:
+            return exact_location_matches
+
+        return matches
+
+    def _collect_replacement_technosphere_exchanges(self, exc: dict) -> List[dict]:
+        """
+        Return the full matching supplier structure from the replacement dataset.
+
+        This is important after migration disaggregation: a single original
+        placeholder can become many zero-valued regional placeholders. We must
+        replace that whole group with the actual exchanges present in the
+        replacement ecoinvent dataset, not fill each split placeholder
+        independently.
+        """
+
+        replacement_ds = self._find_replacement_dataset(exc)
+        if replacement_ds is None:
+            return []
+
+        matches = list(
+            ws.technosphere(
+                replacement_ds,
+                ws.equals("name", exc["name"]),
+                ws.equals("product", exc["product"]),
+            )
+        )
+
+        if matches:
+            return matches
+
+        alt_name = self._toggle_market_name(exc["name"])
+        if alt_name is None:
+            return []
+
+        return list(
+            ws.technosphere(
+                replacement_ds,
+                ws.equals("name", alt_name),
+                ws.equals("product", exc["product"]),
+            )
+        )
+
+    def fill_dataset_data_gaps(self, dataset: dict) -> None:
+        """
+        Fill exchanges with replacement metadata for a whole dataset.
+
+        Technosphere exchanges are handled group-wise so migration-created
+        split placeholders are replaced by the actual supplier structure of the
+        replacement ecoinvent dataset.
+        """
+
+        grouped_techno = {}
+        biosphere_to_fill = []
+
+        for exc in dataset.get("exchanges", []):
+            if "replacement name" not in exc:
+                continue
+
+            if exc["type"] == "technosphere":
+                key = (
+                    *self._replacement_metadata(exc),
+                    exc["type"],
+                    exc["name"],
+                    exc["product"],
+                    exc["unit"],
+                )
+                grouped_techno.setdefault(key, []).append(exc)
+            elif exc["type"] == "biosphere":
+                biosphere_to_fill.append(exc)
+
+        if not grouped_techno and not biosphere_to_fill:
+            return
+
+        filtered_exchanges = []
+        grouped_techno_ids = {
+            id(exc) for excs in grouped_techno.values() for exc in excs
+        }
+        biosphere_ids = {id(exc) for exc in biosphere_to_fill}
+
+        for exc in dataset["exchanges"]:
+            if id(exc) in grouped_techno_ids or id(exc) in biosphere_ids:
+                continue
+            filtered_exchanges.append(exc)
+
+        for grouped_exchanges in grouped_techno.values():
+            template = grouped_exchanges[0]
+            replacements = self._collect_replacement_technosphere_exchanges(template)
+
+            if replacements:
+                for replacement in replacements:
+                    new_exc = template.copy()
+                    new_exc["name"] = replacement["name"]
+                    new_exc["product"] = replacement["product"]
+                    new_exc["location"] = replacement["location"]
+                    new_exc["unit"] = replacement["unit"]
+                    new_exc["amount"] = replacement["amount"]
+                    new_exc.pop("replacement name", None)
+                    new_exc.pop("replacement product", None)
+                    new_exc.pop("replacement location", None)
+                    new_exc.pop("input", None)
+                    filtered_exchanges.append(new_exc)
+            else:
+                fallback_exc = template.copy()
+                self.fill_data_gaps(fallback_exc)
+                filtered_exchanges.append(fallback_exc)
+
+        for exc in biosphere_to_fill:
+            self.fill_data_gaps(exc)
+            filtered_exchanges.append(exc)
+
+        dataset["exchanges"] = filtered_exchanges
+
     def fill_data_gaps(self, exc):
         """
         Some datatsets have the exchange amount set to zero because of ecoinvent license restrictions
@@ -1098,12 +1269,8 @@ class BaseInventoryImport:
                 ):
                     sum_amount = 0
                     if exc["type"] == "technosphere":
-
-                        for e in ws.technosphere(
-                            ds,
-                            ws.equals("name", exc["name"]),
-                            ws.equals("product", exc["product"]),
-                            # ws.equals("location", exc["location"]),
+                        for e in self._find_matching_technosphere_exchanges(
+                            ds, exc["name"], exc
                         ):
                             sum_amount += e["amount"]
 
@@ -1133,11 +1300,8 @@ class BaseInventoryImport:
                             )
                             return
 
-                        for e in ws.technosphere(
-                            ds,
-                            ws.equals("name", n),
-                            ws.equals("product", exc["product"]),
-                            # ws.equals("location", exc["location"]),
+                        for e in self._find_matching_technosphere_exchanges(
+                            ds, n, exc
                         ):
                             sum_amount += e["amount"]
 
@@ -1215,13 +1379,7 @@ class BaseInventoryImport:
                                 )
                             )
 
-                if exchange["type"] in (
-                    "technosphere",
-                    "biosphere",
-                ):
-                    # check if amount is missing and need to be filled
-                    if "replacement name" in exchange:
-                        self.fill_data_gaps(exchange)
+            self.fill_dataset_data_gaps(dataset)
 
         # Add a `code` field if missing
         for dataset in self.import_db.data:

--- a/premise/new_database.py
+++ b/premise/new_database.py
@@ -1350,8 +1350,7 @@ class NewDatabase:
 
         for s, scenario in enumerate(self.scenarios):
             can_use_fast_export = (
-                scenario.get("database") is not None
-                or "database filepath" in scenario
+                scenario.get("database") is not None or "database filepath" in scenario
             )
 
             if can_use_fast_export:

--- a/premise/new_database.py
+++ b/premise/new_database.py
@@ -1371,19 +1371,25 @@ class NewDatabase:
                     load_metadata=True,
                     warning=False,
                 )
-                scenario["database"] = prepare_db_for_fast_export(
-                    scenario=scenario,
-                    name=name[s],
-                    biosphere_name=self.biosphere_name,
-                    version=self.version,
-                )
+                try:
+                    scenario["database"] = prepare_db_for_fast_export(
+                        scenario=scenario,
+                        name=name[s],
+                        biosphere_name=self.biosphere_name,
+                        version=self.version,
+                    )
+                except ValueError:
+                    self.generate_change_report()
+                    raise ValueError(
+                        "The database is not ready for export: MAJOR anomalies found. Check the change report."
+                    )
 
                 scenario["database name"] = name[s]
                 write_brightway_database(
                     scenario["database"],
                     name[s],
                     fast=True,
-                    check_internal=False,
+                    check_internal=True,
                 )
                 end_of_process(scenario)
                 continue

--- a/premise/new_database.py
+++ b/premise/new_database.py
@@ -1306,6 +1306,8 @@ class NewDatabase:
         write_brightway_database(
             data=self.database,
             name=name,
+            fast=True,
+            check_internal=False,
         )
 
         if self.generate_reports:

--- a/premise/new_database.py
+++ b/premise/new_database.py
@@ -33,6 +33,7 @@ from .export import (
     generate_scenario_factor_file,
     generate_superstructure_db,
     prepare_db_for_export,
+    prepare_db_for_fast_export,
 )
 from .external import _update_external_scenarios
 from .external_data_validation import check_external_scenarios
@@ -793,9 +794,11 @@ class NewDatabase:
 
         # else, extract the database, pickle it for next time and return it
         print("Cannot find cached inventories. Will create them now for next time...")
-        data = self.__import_inventories()
-        data, inventories_metadata_cache_filepath = create_cache(data, file_name)
-        self._replace_imported_inventory_tail(data)
+        inventory_start = len(self.database)
+        self.__import_inventories(collect_data=False)
+        _, inventories_metadata_cache_filepath = create_cache(
+            self.database[inventory_start:], file_name
+        )
         self.inventories_cache_filepath = resolve_cache_ref(file_name)
         self.inventories_metadata_cache_filepath = inventories_metadata_cache_filepath
         self._reload_original_database_from_cache_for_update = True
@@ -815,7 +818,7 @@ class NewDatabase:
             self.source, self.source_type, self.source_file_path, self.version
         ).prepare_datasets(self.keep_source_db_uncertainty)
 
-    def __import_inventories(self) -> List[dict]:
+    def __import_inventories(self, collect_data: bool = True) -> List[dict]:
         """
         This method will trigger the import of a number of pickled inventories
         and merge them into the database dictionary.
@@ -942,7 +945,8 @@ class NewDatabase:
                 keep_uncertainty_data=self.keep_imports_uncertainty,
             )
             datasets = inventory.merge_inventory()
-            data.extend(datasets)
+            if collect_data:
+                data.extend(datasets)
             self.database.extend(datasets)
             unlinked.extend(inventory.list_unlinked)
 
@@ -950,23 +954,6 @@ class NewDatabase:
             raise ValueError("Fix the unlinked exchanges before proceeding")
 
         return data
-
-    def _replace_imported_inventory_tail(self, inventories: List[dict]) -> None:
-        """Rewrite the imported inventory tail using the cached trimmed datasets.
-
-        On a cache miss, ``__import_inventories`` appends full importer output to
-        ``self.database`` so subsequent imports can detect newly added datasets.
-        Once the cache is written, replace that appended tail with the trimmed
-        datasets returned by ``create_cache`` so the miss path matches a cache hit.
-        """
-
-        if not inventories:
-            return
-
-        if len(self.database) < len(inventories):
-            raise ValueError("Cannot normalize imported inventories in memory.")
-
-        self.database[-len(inventories) :] = inventories
 
     @staticmethod
     def _clear_inventory_importer_state() -> None:
@@ -1360,9 +1347,38 @@ class NewDatabase:
         check_presence_biosphere_database(self.biosphere_name)
 
         print("Write new database(s) to Brightway.")
-        original_database = self._load_original_database()
 
         for s, scenario in enumerate(self.scenarios):
+            can_use_fast_export = (
+                scenario.get("database") is not None
+                or "database filepath" in scenario
+            )
+
+            if can_use_fast_export:
+                scenario = load_database(
+                    scenario=scenario,
+                    original_database=[],
+                    load_metadata=True,
+                    warning=False,
+                )
+                scenario["database"] = prepare_db_for_fast_export(
+                    scenario=scenario,
+                    name=name[s],
+                    biosphere_name=self.biosphere_name,
+                    version=self.version,
+                )
+
+                scenario["database name"] = name[s]
+                write_brightway_database(
+                    scenario["database"],
+                    name[s],
+                    fast=True,
+                    check_internal=False,
+                )
+                end_of_process(scenario)
+                continue
+
+            original_database = self._load_original_database()
             scenario = load_database(
                 scenario=scenario,
                 original_database=original_database,

--- a/premise/new_database.py
+++ b/premise/new_database.py
@@ -5,6 +5,7 @@ as well as export it back.
 """
 
 import gc
+import inspect
 import logging
 import os
 import pickle
@@ -697,8 +698,10 @@ class NewDatabase:
             else:
                 imported_inventory_data = True
             # A cache miss imports inventories directly into ``self.database``
-            # before writing the cache files, so the in-memory database is
-            # complete in both the hit and miss cases here.
+            # before replacing the imported tail with the trimmed cached
+            # representation, so the inventory coverage is complete in both the
+            # hit and miss cases here and the original form can be reloaded from
+            # cache when needed.
             self._database_is_complete = True
         else:
             self.__import_inventories()
@@ -795,10 +798,16 @@ class NewDatabase:
         # else, extract the database, pickle it for next time and return it
         print("Cannot find cached inventories. Will create them now for next time...")
         inventory_start = len(self.database)
-        self.__import_inventories(collect_data=False)
-        _, inventories_metadata_cache_filepath = create_cache(
+        import_inventories = self.__import_inventories
+        if "collect_data" in inspect.signature(import_inventories).parameters:
+            import_inventories(collect_data=False)
+        else:
+            import_inventories()
+
+        trimmed_inventories, inventories_metadata_cache_filepath = create_cache(
             self.database[inventory_start:], file_name
         )
+        self.database[inventory_start:] = trimmed_inventories
         self.inventories_cache_filepath = resolve_cache_ref(file_name)
         self.inventories_metadata_cache_filepath = inventories_metadata_cache_filepath
         self._reload_original_database_from_cache_for_update = True

--- a/premise/utils.py
+++ b/premise/utils.py
@@ -1009,7 +1009,8 @@ def _trim_scenario_dataset_in_place(ds: Dict[str, Any]) -> Dict[str, Any]:
         if field in _SCENARIO_TRIMMED_DATASET_FIELDS
     }
     trimmed_dataset["exchanges"] = [
-        _trim_scenario_exchange(exchange)[0] for exchange in trimmed_dataset["exchanges"]
+        _trim_scenario_exchange(exchange)[0]
+        for exchange in trimmed_dataset["exchanges"]
     ]
     ds.clear()
     ds.update(trimmed_dataset)

--- a/premise/utils.py
+++ b/premise/utils.py
@@ -480,10 +480,11 @@ def dump_database(scenario: Dict[str, Any]) -> Dict[str, Any]:
 
     # generate random name
     name = f"{uuid.uuid4().hex}.pickle"
-    # dump as pickle
-    with open(DIR_CACHED_FILES / name, "wb") as f:
-        pickle.dump(scenario["database"], f)
-    scenario["database filepath"] = DIR_CACHED_FILES / name
+    database_cache_ref, metadata_cache_ref = create_scenario_cache(
+        scenario["database"], DIR_CACHED_FILES / name
+    )
+    scenario["database filepath"] = database_cache_ref
+    scenario["database metadata filepath"] = metadata_cache_ref
     del scenario["database"]
 
     return scenario
@@ -554,6 +555,23 @@ def _iter_cache_bundle_paths(file_name: Path) -> Iterable[Path]:
             shard_file = file_name.parent / shard_file
 
         yield shard_file
+
+
+def delete_cache_ref(cache_ref: Path) -> None:
+    """Delete a legacy cache file or all files referenced by a manifest-backed cache."""
+
+    cache_ref = resolve_cache_ref(cache_ref)
+
+    if _is_cache_manifest(cache_ref):
+        for shard_file in _iter_cache_bundle_paths(cache_ref):
+            if shard_file.exists():
+                shard_file.unlink()
+        if cache_ref.exists():
+            cache_ref.unlink()
+        return
+
+    if cache_ref.exists():
+        cache_ref.unlink()
 
 
 def load_cached_database(cache_ref: Path) -> List[Dict[str, Any]]:
@@ -641,21 +659,20 @@ def load_database(
 
     else:
         filepath = scenario["database filepath"]
-
-        # load pickle
-        with open(filepath, "rb") as f:
-            scenario["database"] = pickle.load(f)
+        scenario["database"] = load_cached_database(filepath)
 
         # delete the file
         if delete:
-            filepath.unlink()
+            delete_cache_ref(filepath)
 
     if load_metadata:
-
-        filepaths = [
-            scenario["database metadata cache filepath"],
-            scenario["inventories metadata cache filepath"],
-        ]
+        if "database metadata filepath" in scenario:
+            filepaths = [scenario["database metadata filepath"]]
+        else:
+            filepaths = [
+                scenario["database metadata cache filepath"],
+                scenario["inventories metadata cache filepath"],
+            ]
         datasets_by_key = {
             (ds["name"], ds["reference product"], ds["location"]): ds
             for ds in scenario["database"]
@@ -673,7 +690,11 @@ def load_database(
                     if ds is None:
                         continue
 
+                    exchange_metadata = metadata_values.get("__exchange_metadata__")
+
                     for k, v in metadata_values.items():
+                        if k == "__exchange_metadata__":
+                            continue
                         if k in [
                             "code",
                             "worksheet name",
@@ -709,13 +730,36 @@ def load_database(
                             elif isinstance(ds[k], dict):
                                 ds[k].update(v)
 
-    # re-attribute a code to every dataset
-    uuids = get_uuids(scenario["database"])
+                    if exchange_metadata:
+                        for exchange, exchange_values in zip(
+                            ds.get("exchanges", []), exchange_metadata
+                        ):
+                            for k, v in exchange_values.items():
+                                if v is None or v == "None" or v == "nan" or not v:
+                                    continue
+
+                                if k not in exchange:
+                                    exchange[k] = v
+                                elif exchange[k] is None:
+                                    exchange[k] = v
+                                elif isinstance(exchange[k], list):
+                                    exchange[k].extend(v)
+                                elif isinstance(exchange[k], str):
+                                    try:
+                                        if len(exchange[k]) != len(v):
+                                            exchange[k] = f"{exchange[k]}. {v}"
+                                    except Exception as exc:
+                                        raise ValueError(
+                                            f"Failed to merge exchange metadata for {ds.get('name')}: "
+                                            f"key={k}, existing={exchange[k]!r}, new={v!r}, error={exc}"
+                                        ) from exc
+                                elif isinstance(exchange[k], dict):
+                                    exchange[k].update(v)
+
+    # scenario caches can preserve dataset codes directly; fall back to
+    # generating new identifiers only when a dataset has none.
     for ds in scenario["database"]:
-        key = (ds["name"], ds["reference product"], ds["location"])
-        if key in uuids:
-            ds["code"] = uuids[key]
-        else:
+        if not ds.get("code"):
             ds["code"] = str(uuid.uuid4().hex)
 
     if "database filepath" in scenario:
@@ -732,12 +776,22 @@ def delete_all_pickles(filepath: Optional[Path] = None) -> None:
     """
 
     if filepath is not None:
-        for file in DIR_CACHED_FILES.glob("*.pickle"):
-            if file == filepath:
-                print(f"File {file} deleted.")
-                file.unlink()
-    else:
-        for file in DIR_CACHED_FILES.glob("*.pickle"):
+        resolved = resolve_cache_ref(filepath)
+        if resolved.exists():
+            print(f"File {resolved} deleted.")
+        delete_cache_ref(resolved)
+        metadata_ref = resolve_cache_ref(
+            Path(str(filepath).replace(".pickle", " (metadata).pickle"))
+        )
+        if metadata_ref.exists():
+            delete_cache_ref(metadata_ref)
+        return
+
+    for manifest in DIR_CACHED_FILES.glob(f"*{CACHE_MANIFEST_SUFFIX}"):
+        delete_cache_ref(manifest)
+
+    for file in DIR_CACHED_FILES.glob("*.pickle"):
+        if file.exists():
             file.unlink()
 
 
@@ -808,6 +862,160 @@ def trim_exchanges(exc: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+_CACHE_TRIMMED_DATASET_FIELDS = {
+    "name",
+    "reference product",
+    "location",
+    "unit",
+    "exchanges",
+    "comment",
+}
+
+_CACHE_METADATA_EXCLUDED_FIELDS = {
+    "name",
+    "reference product",
+    "location",
+    "unit",
+    "exchanges",
+    "type",
+    "comment",
+}
+
+_SCENARIO_TRIMMED_DATASET_FIELDS = {
+    "database",
+    "code",
+    "name",
+    "reference product",
+    "location",
+    "unit",
+    "type",
+    "exchanges",
+}
+
+_SCENARIO_TRIMMED_EXCHANGE_FIELDS = {
+    "input",
+    "amount",
+    "type",
+    "uncertainty type",
+    "loc",
+    "scale",
+    "shape",
+    "minimum",
+    "maximum",
+    "production volume",
+    "product",
+    "name",
+    "unit",
+    "location",
+    "categories",
+}
+
+_SCENARIO_METADATA_EXCLUDED_FIELDS = {
+    "name",
+    "reference product",
+    "location",
+    "unit",
+    "type",
+    "exchanges",
+    "database",
+    "code",
+}
+
+
+def _has_cache_value(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str) and value in {"None", "nan", ""}:
+        return False
+    if isinstance(value, (list, tuple, dict, set)):
+        return True
+
+    try:
+        return bool(pd.notna(value))
+    except Exception:
+        return True
+
+
+def _metadata_for_cache_dataset(ds: Dict[str, Any]) -> Tuple[tuple, Dict[str, Any]]:
+    key = (ds["name"], ds["reference product"], ds["location"])
+    metadata = {
+        field: value
+        for field, value in ds.items()
+        if field not in _CACHE_METADATA_EXCLUDED_FIELDS
+        and value is not None
+        and value != "None"
+        and value != "nan"
+    }
+    return key, metadata
+
+
+def _trim_cache_dataset_in_place(ds: Dict[str, Any]) -> Dict[str, Any]:
+    trimmed_dataset = {
+        field: value
+        for field, value in ds.items()
+        if field in _CACHE_TRIMMED_DATASET_FIELDS
+    }
+    trimmed_dataset["exchanges"] = [
+        trim_exchanges(exchange) for exchange in trimmed_dataset["exchanges"]
+    ]
+    ds.clear()
+    ds.update(trimmed_dataset)
+    return ds
+
+
+def _trim_scenario_exchange(
+    exchange: Dict[str, Any],
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    compact_exchange: Dict[str, Any] = {}
+    exchange_metadata: Dict[str, Any] = {}
+
+    for field, value in exchange.items():
+        if not _has_cache_value(value):
+            continue
+
+        target = (
+            compact_exchange
+            if field in _SCENARIO_TRIMMED_EXCHANGE_FIELDS
+            else exchange_metadata
+        )
+        target[field] = value
+
+    return compact_exchange, exchange_metadata
+
+
+def _metadata_for_scenario_dataset(ds: Dict[str, Any]) -> Tuple[tuple, Dict[str, Any]]:
+    key = (ds["name"], ds["reference product"], ds["location"])
+    metadata = {
+        field: value
+        for field, value in ds.items()
+        if field not in _SCENARIO_METADATA_EXCLUDED_FIELDS and _has_cache_value(value)
+    }
+
+    exchange_metadata = []
+    for exchange in ds.get("exchanges", []):
+        _, compact_exchange_metadata = _trim_scenario_exchange(exchange)
+        exchange_metadata.append(compact_exchange_metadata)
+
+    if any(exchange_metadata):
+        metadata["__exchange_metadata__"] = exchange_metadata
+
+    return key, metadata
+
+
+def _trim_scenario_dataset_in_place(ds: Dict[str, Any]) -> Dict[str, Any]:
+    trimmed_dataset = {
+        field: value
+        for field, value in ds.items()
+        if field in _SCENARIO_TRIMMED_DATASET_FIELDS
+    }
+    trimmed_dataset["exchanges"] = [
+        _trim_scenario_exchange(exchange)[0] for exchange in trimmed_dataset["exchanges"]
+    ]
+    ds.clear()
+    ds.update(trimmed_dataset)
+    return ds
+
+
 def _chunk_sequence(
     sequence: Sequence[Any], chunk_size: int
 ) -> Iterable[Sequence[Any]]:
@@ -875,61 +1083,106 @@ def create_cache(
     :rtype: tuple
     """
 
-    metadata = {
-        (ds["name"], ds["reference product"], ds["location"]): {
-            k: v
-            for k, v in ds.items()
-            if k
-            not in [
-                "name",
-                "reference product",
-                "location",
-                "unit",
-                "exchanges",
-                "type",
-                "comment",
-            ]
-            and v is not None
-            and v != "None"
-            and v != "nan"
-        }
-        for ds in database
-    }
-
-    database = [
-        {
-            k: v
-            for k, v in ds.items()
-            if k
-            in [
-                "name",
-                "reference product",
-                "location",
-                "unit",
-                "exchanges",
-                "comment",
-            ]
-        }
-        for ds in database
-    ]
-
-    for ds in database:
-        ds["exchanges"] = [trim_exchanges(exc) for exc in ds["exchanges"]]
-
     # make sure the directory exists
     DIR_CACHED_DB.mkdir(parents=True, exist_ok=True)
 
     metadata_cache_file = Path(str(file_name).replace(".pickle", " (metadata).pickle"))
-    metadata_cache_ref = _write_cache_shards(
-        metadata_cache_file,
-        _chunk_mapping(metadata, chunk_size=5_000),
-        payload_kind="metadata",
-    )
+    metadata_chunk_size = 5_000
+    metadata_shard_paths = []
+    metadata_chunk: Dict[tuple, Dict[str, Any]] = {}
+
+    for dataset in database:
+        key, metadata = _metadata_for_cache_dataset(dataset)
+        if metadata:
+            metadata_chunk[key] = metadata
+
+        _trim_cache_dataset_in_place(dataset)
+
+        if len(metadata_chunk) >= metadata_chunk_size:
+            shard_path = metadata_cache_file.with_name(
+                f"{metadata_cache_file.name}.part-{len(metadata_shard_paths):04d}.pickle"
+            )
+            with open(shard_path, "wb") as file:
+                pickle.dump(metadata_chunk, file)
+            metadata_shard_paths.append(shard_path)
+            metadata_chunk = {}
+
+    if metadata_chunk:
+        shard_path = metadata_cache_file.with_name(
+            f"{metadata_cache_file.name}.part-{len(metadata_shard_paths):04d}.pickle"
+        )
+        with open(shard_path, "wb") as file:
+            pickle.dump(metadata_chunk, file)
+        metadata_shard_paths.append(shard_path)
+    elif not metadata_shard_paths:
+        shard_path = metadata_cache_file.with_name(
+            f"{metadata_cache_file.name}.part-0000.pickle"
+        )
+        with open(shard_path, "wb") as file:
+            pickle.dump({}, file)
+        metadata_shard_paths.append(shard_path)
 
     with open(file_name, "wb") as file:
         pickle.dump(database, file)
 
+    metadata_cache_ref = _write_cache_manifest(
+        metadata_cache_file, metadata_shard_paths, "metadata"
+    )
+
     return database, metadata_cache_ref
+
+
+def create_scenario_cache(
+    database: List[Dict[str, Any]], file_name: Path
+) -> Tuple[Path, Path]:
+    """Persist a post-update scenario database in compact shard-backed files."""
+
+    DIR_CACHED_FILES.mkdir(parents=True, exist_ok=True)
+
+    metadata_cache_file = Path(str(file_name).replace(".pickle", " (metadata).pickle"))
+    metadata_chunk_size = 1_000
+    metadata_shard_paths = []
+    metadata_chunk: Dict[tuple, Dict[str, Any]] = {}
+
+    for dataset in database:
+        key, metadata = _metadata_for_scenario_dataset(dataset)
+        if metadata:
+            metadata_chunk[key] = metadata
+
+        _trim_scenario_dataset_in_place(dataset)
+
+        if len(metadata_chunk) >= metadata_chunk_size:
+            shard_path = metadata_cache_file.with_name(
+                f"{metadata_cache_file.name}.part-{len(metadata_shard_paths):04d}.pickle"
+            )
+            with open(shard_path, "wb") as file:
+                pickle.dump(metadata_chunk, file)
+            metadata_shard_paths.append(shard_path)
+            metadata_chunk = {}
+
+    if metadata_chunk:
+        shard_path = metadata_cache_file.with_name(
+            f"{metadata_cache_file.name}.part-{len(metadata_shard_paths):04d}.pickle"
+        )
+        with open(shard_path, "wb") as file:
+            pickle.dump(metadata_chunk, file)
+        metadata_shard_paths.append(shard_path)
+    elif not metadata_shard_paths:
+        shard_path = metadata_cache_file.with_name(
+            f"{metadata_cache_file.name}.part-0000.pickle"
+        )
+        with open(shard_path, "wb") as file:
+            pickle.dump({}, file)
+        metadata_shard_paths.append(shard_path)
+
+    database_cache_ref = _write_cache_shards(
+        file_name, _chunk_sequence(database, 2_500), "database"
+    )
+    metadata_cache_ref = _write_cache_manifest(
+        metadata_cache_file, metadata_shard_paths, "metadata"
+    )
+
+    return database_cache_ref, metadata_cache_ref
 
 
 def load_metadata(file_name: Path) -> Dict[str, Any]:

--- a/premise/validation.py
+++ b/premise/validation.py
@@ -846,6 +846,32 @@ class BaseDatasetValidator:
         self.reformat_parameters()
         self.add_missing_classifications()
         self.check_uncertainty()
+        self._finalize_logs()
+
+    def run_fast_export_checks(self):
+        """
+        Run a reduced validation pass for the fast Brightway export path.
+        This keeps cheap structural and consistency checks while avoiding
+        the heavier checks that require the full source database context.
+        """
+
+        print("Running core export checks...")
+        self.check_matrix_squareness()
+        self.validate_dataset_structure()
+        self.verify_data_consistency()
+        self.check_relinking_logic()
+        self.check_for_orphaned_datasets()
+        self.check_for_duplicates()
+        self.check_for_circular_references()
+        self.check_database_name()
+        self.remove_unused_fields()
+        self.correct_fields_format()
+        self.check_amount_format()
+        self.reformat_parameters()
+        self.check_uncertainty()
+        self._finalize_logs()
+
+    def _finalize_logs(self):
         self.save_log()
         if len(self.minor_issues_log) > 0:
             print("Minor anomalies found: check the change report.")

--- a/tests/test_brightway_writers.py
+++ b/tests/test_brightway_writers.py
@@ -66,9 +66,7 @@ def test_write_brightway25_database_fast_prints_completion_message(monkeypatch, 
     assert "Brightway database written: fast-db" in capsys.readouterr().out
 
 
-def test_write_brightway25_database_fast_prints_overwrite_message(
-    monkeypatch, capsys
-):
+def test_write_brightway25_database_fast_prints_overwrite_message(monkeypatch, capsys):
     monkeypatch.setattr(brightway25_module, "databases", {"fast-db": {}})
     monkeypatch.setattr(brightway25_module, "change_db_name", lambda data, name: None)
     monkeypatch.setattr(brightway25_module, "link_internal", lambda data: None)

--- a/tests/test_brightway_writers.py
+++ b/tests/test_brightway_writers.py
@@ -20,10 +20,13 @@ def test_collect_fast_export_geography_discards_unknown_geocollections():
     assert locations == {"CH", "UNKNOWN", "GLO"}
 
 
-def test_write_brightway25_database_fast_prints_completion_message(
-    monkeypatch, capsys
-):
-    calls = {"change_db_name": None, "check_internal": 0, "compact": None, "write": None}
+def test_write_brightway25_database_fast_prints_completion_message(monkeypatch, capsys):
+    calls = {
+        "change_db_name": None,
+        "check_internal": 0,
+        "compact": None,
+        "write": None,
+    }
 
     monkeypatch.setattr(
         brightway25_module,

--- a/tests/test_brightway_writers.py
+++ b/tests/test_brightway_writers.py
@@ -1,0 +1,103 @@
+import premise.brightway2 as brightway2_module
+import premise.brightway25 as brightway25_module
+
+
+def test_collect_fast_export_geography_discards_unknown_geocollections():
+    data = [
+        {"type": "process", "location": "CH"},
+        {"type": "process", "location": "UNKNOWN"},
+        {"type": "product", "location": "GLO"},
+        {"type": "process", "location": None},
+    ]
+
+    geocollections, locations = brightway25_module._collect_fast_export_geography(
+        data=data,
+        process_node_types={"process"},
+        get_geocollection=lambda location: {"CH": "ecoinvent"}.get(location),
+    )
+
+    assert geocollections == ["ecoinvent"]
+    assert locations == {"CH", "UNKNOWN", "GLO"}
+
+
+def test_write_brightway25_database_fast_prints_completion_message(
+    monkeypatch, capsys
+):
+    calls = {"change_db_name": None, "check_internal": 0, "compact": None, "write": None}
+
+    monkeypatch.setattr(
+        brightway25_module,
+        "change_db_name",
+        lambda data, name: calls.__setitem__("change_db_name", (data, name)),
+    )
+    monkeypatch.setattr(brightway25_module, "link_internal", lambda data: None)
+    monkeypatch.setattr(
+        brightway25_module,
+        "check_internal_linking",
+        lambda data: calls.__setitem__("check_internal", calls["check_internal"] + 1),
+    )
+    monkeypatch.setattr(
+        brightway25_module,
+        "_compact_payload_for_fast_write",
+        lambda data, name: calls.__setitem__("compact", (data, name)),
+    )
+    monkeypatch.setattr(
+        brightway25_module,
+        "_write_processed_database_fast",
+        lambda data, name: calls.__setitem__("write", (data, name)),
+    )
+
+    data = [{"code": "a", "exchanges": []}]
+
+    brightway25_module.write_brightway_database(
+        data=data,
+        name="fast-db",
+        fast=True,
+        check_internal=True,
+    )
+
+    assert calls["change_db_name"] == (data, "fast-db")
+    assert calls["check_internal"] == 1
+    assert calls["compact"] == (data, "fast-db")
+    assert calls["write"] == (data, "fast-db")
+    assert "Brightway database written: fast-db" in capsys.readouterr().out
+
+
+def test_write_brightway2_database_prints_completion_message(monkeypatch, capsys):
+    calls = {"change_db_name": None, "check_internal": 0, "write": 0}
+
+    monkeypatch.setattr(
+        brightway2_module,
+        "change_db_name",
+        lambda data, name: calls.__setitem__("change_db_name", (data, name)),
+    )
+    monkeypatch.setattr(brightway2_module, "link_internal", lambda data: None)
+    monkeypatch.setattr(
+        brightway2_module,
+        "check_internal_linking",
+        lambda data: calls.__setitem__("check_internal", calls["check_internal"] + 1),
+    )
+
+    class DummyImporter:
+        def __init__(self, name, data):
+            self.name = name
+            self.data = data
+
+        def write_database(self):
+            calls["write"] += 1
+
+    monkeypatch.setattr(brightway2_module, "BW2Importer", DummyImporter)
+
+    data = [{"code": "a", "exchanges": []}]
+
+    brightway2_module.write_brightway_database(
+        data=data,
+        name="bw2-db",
+        fast=False,
+        check_internal=True,
+    )
+
+    assert calls["change_db_name"] == (data, "bw2-db")
+    assert calls["check_internal"] == 1
+    assert calls["write"] == 1
+    assert "Brightway database written: bw2-db" in capsys.readouterr().out

--- a/tests/test_brightway_writers.py
+++ b/tests/test_brightway_writers.py
@@ -66,6 +66,36 @@ def test_write_brightway25_database_fast_prints_completion_message(monkeypatch, 
     assert "Brightway database written: fast-db" in capsys.readouterr().out
 
 
+def test_write_brightway25_database_fast_prints_overwrite_message(
+    monkeypatch, capsys
+):
+    monkeypatch.setattr(brightway25_module, "databases", {"fast-db": {}})
+    monkeypatch.setattr(brightway25_module, "change_db_name", lambda data, name: None)
+    monkeypatch.setattr(brightway25_module, "link_internal", lambda data: None)
+    monkeypatch.setattr(brightway25_module, "check_internal_linking", lambda data: None)
+    monkeypatch.setattr(
+        brightway25_module,
+        "_compact_payload_for_fast_write",
+        lambda data, name: None,
+    )
+    monkeypatch.setattr(
+        brightway25_module,
+        "_write_processed_database_fast",
+        lambda data, name: None,
+    )
+
+    brightway25_module.write_brightway_database(
+        data=[{"code": "a", "exchanges": []}],
+        name="fast-db",
+        fast=True,
+        check_internal=True,
+    )
+
+    output = capsys.readouterr().out
+    assert "Database fast-db already exists: it will be overwritten." in output
+    assert "Brightway database written: fast-db" in output
+
+
 def test_write_brightway2_database_prints_completion_message(monkeypatch, capsys):
     calls = {"change_db_name": None, "check_internal": 0, "write": 0}
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pandas as pd
 import pytest
 
@@ -103,6 +105,71 @@ def test_remove_uncertainty():
         for exc in ds["exchanges"]:
             if "uncertainty_type" in exc:
                 assert exc["uncertainty_type"] == 0
+
+
+def test_prepare_db_for_fast_export_runs_core_checks(monkeypatch):
+    captured = {}
+    prepared_database = [{"name": "prepared"}]
+
+    class DummyValidator:
+        def __init__(
+            self,
+            model,
+            scenario,
+            year,
+            regions,
+            original_database,
+            database,
+            db_name,
+            biosphere_name,
+            version,
+        ):
+            captured["init"] = {
+                "model": model,
+                "scenario": scenario,
+                "year": year,
+                "regions": regions,
+                "original_database": original_database,
+                "database": database,
+                "db_name": db_name,
+                "biosphere_name": biosphere_name,
+                "version": version,
+            }
+            self.database = prepared_database
+
+        def run_fast_export_checks(self):
+            captured["run_fast_export_checks"] = True
+
+    monkeypatch.setattr("premise.export.BaseDatasetValidator", DummyValidator)
+
+    scenario = {
+        "model": "image",
+        "pathway": "SSP2-Base",
+        "year": 2030,
+        "iam data": SimpleNamespace(regions=["EUR"]),
+        "database": [{"name": "raw"}],
+    }
+
+    result = prepare_db_for_fast_export(
+        scenario=scenario,
+        name="test-db",
+        version="3.12",
+        biosphere_name="test-biosphere",
+    )
+
+    assert captured["init"] == {
+        "model": "image",
+        "scenario": "SSP2-Base",
+        "year": 2030,
+        "regions": ["EUR"],
+        "original_database": [],
+        "database": [{"name": "raw"}],
+        "db_name": "test-db",
+        "biosphere_name": "test-biosphere",
+        "version": "3.12",
+    }
+    assert captured["run_fast_export_checks"] is True
+    assert result == prepared_database
 
 
 def test_aggregate_duplicate_superstructure_rows_sums_biosphere_collisions():

--- a/tests/test_import_inventories.py
+++ b/tests/test_import_inventories.py
@@ -1,5 +1,6 @@
 # content of test_activity_maps.py
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -52,6 +53,11 @@ def get_db():
     ]
     version = "3.5"
     return db, version
+
+
+class DummyInventoryImport(BaseInventoryImport):
+    def load_inventory(self):
+        return SimpleNamespace(data=[])
 
 
 def test_file_exists():
@@ -172,3 +178,183 @@ def test_get_classifications_repairs_mojibake(tmp_path, monkeypatch):
     }
 
     get_classifications.cache_clear()
+
+
+def test_fill_data_gaps_prefers_matching_supplier_location(tmp_path):
+    testpath = tmp_path / "dummy.xlsx"
+    testpath.write_text("")
+
+    reference_db = [
+        {
+            "name": "pig iron production",
+            "reference product": "pig iron",
+            "location": "RER",
+            "exchanges": [
+                {
+                    "name": "market for coke",
+                    "product": "coke",
+                    "location": "GLO",
+                    "amount": 9.72,
+                    "type": "technosphere",
+                    "unit": "megajoule",
+                },
+                {
+                    "name": "market for coke",
+                    "product": "coke",
+                    "location": "RoW",
+                    "amount": 9.68,
+                    "type": "technosphere",
+                    "unit": "megajoule",
+                },
+            ],
+        }
+    ]
+
+    importer = DummyInventoryImport(
+        reference_db,
+        version_in="3.8",
+        version_out="3.8",
+        path=testpath,
+        system_model="cutoff",
+    )
+
+    exchange = {
+        "name": "market for coke",
+        "product": "coke",
+        "location": "GLO",
+        "unit": "megajoule",
+        "type": "technosphere",
+        "replacement name": "pig iron production",
+        "replacement product": "pig iron",
+        "replacement location": "RER",
+    }
+
+    importer.fill_data_gaps(exchange)
+
+    assert exchange["amount"] == pytest.approx(9.72)
+    assert "replacement name" not in exchange
+    assert "replacement product" not in exchange
+    assert "replacement location" not in exchange
+
+
+def test_fill_dataset_data_gaps_replaces_migrated_split_markets(tmp_path):
+    testpath = tmp_path / "dummy.xlsx"
+    testpath.write_text("")
+
+    reference_db = [
+        {
+            "name": "pig iron production",
+            "reference product": "pig iron",
+            "location": "RER",
+            "unit": "kilogram",
+            "exchanges": [
+                {
+                    "name": "market for coke",
+                    "product": "coke",
+                    "location": "RoW",
+                    "amount": 9.724,
+                    "type": "technosphere",
+                    "unit": "megajoule",
+                },
+                {
+                    "name": "market group for hard coal",
+                    "product": "hard coal",
+                    "location": "RER",
+                    "amount": 0.15,
+                    "type": "technosphere",
+                    "unit": "kilogram",
+                },
+            ],
+        }
+    ]
+
+    importer = DummyInventoryImport(
+        reference_db,
+        version_in="3.8",
+        version_out="3.8",
+        path=testpath,
+        system_model="cutoff",
+    )
+
+    dataset = {
+        "name": "pig iron production, blast furnace, with carbon capture and storage",
+        "reference product": "pig iron",
+        "location": "GLO",
+        "unit": "kilogram",
+        "exchanges": [
+            {
+                "name": "pig iron production, blast furnace, with carbon capture and storage",
+                "product": "pig iron",
+                "amount": 1,
+                "type": "production",
+                "unit": "kilogram",
+            },
+            {
+                "name": "market for coke",
+                "product": "coke",
+                "location": "CN",
+                "unit": "megajoule",
+                "amount": 0,
+                "type": "technosphere",
+                "replacement name": "pig iron production",
+                "replacement product": "pig iron",
+                "replacement location": "RER",
+            },
+            {
+                "name": "market for coke",
+                "product": "coke",
+                "location": "RoW",
+                "unit": "megajoule",
+                "amount": 0,
+                "type": "technosphere",
+                "replacement name": "pig iron production",
+                "replacement product": "pig iron",
+                "replacement location": "RER",
+            },
+            {
+                "name": "market for hard coal",
+                "product": "hard coal",
+                "location": "DE",
+                "unit": "kilogram",
+                "amount": 0,
+                "type": "technosphere",
+                "replacement name": "pig iron production",
+                "replacement product": "pig iron",
+                "replacement location": "RER",
+            },
+            {
+                "name": "market for hard coal",
+                "product": "hard coal",
+                "location": "FR",
+                "unit": "kilogram",
+                "amount": 0,
+                "type": "technosphere",
+                "replacement name": "pig iron production",
+                "replacement product": "pig iron",
+                "replacement location": "RER",
+            },
+        ],
+    }
+
+    importer.fill_dataset_data_gaps(dataset)
+
+    techno = [exc for exc in dataset["exchanges"] if exc["type"] == "technosphere"]
+
+    assert techno == [
+        {
+            "name": "market for coke",
+            "product": "coke",
+            "location": "RoW",
+            "unit": "megajoule",
+            "amount": pytest.approx(9.724),
+            "type": "technosphere",
+        },
+        {
+            "name": "market group for hard coal",
+            "product": "hard coal",
+            "location": "RER",
+            "unit": "kilogram",
+            "amount": pytest.approx(0.15),
+            "type": "technosphere",
+        },
+    ]

--- a/tests/test_new_database.py
+++ b/tests/test_new_database.py
@@ -268,7 +268,9 @@ def test_write_db_to_brightway_fast_path_runs_internal_check(monkeypatch):
     monkeypatch.setattr(
         new_database_module,
         "delete_all_pickles",
-        lambda: captured.__setitem__("pickles_deleted", captured["pickles_deleted"] + 1),
+        lambda: captured.__setitem__(
+            "pickles_deleted", captured["pickles_deleted"] + 1
+        ),
     )
 
     obj = object.__new__(NewDatabase)
@@ -534,7 +536,9 @@ def test_write_superstructure_to_brightway_uses_fast_writer_after_full_preparati
     monkeypatch.setattr(
         new_database_module,
         "delete_all_pickles",
-        lambda: captured.__setitem__("pickles_deleted", captured["pickles_deleted"] + 1),
+        lambda: captured.__setitem__(
+            "pickles_deleted", captured["pickles_deleted"] + 1
+        ),
     )
 
     obj = object.__new__(NewDatabase)

--- a/tests/test_new_database.py
+++ b/tests/test_new_database.py
@@ -222,6 +222,181 @@ def test_write_superstructure_to_brightway_requires_registered_biosphere(monkeyp
         obj.write_superstructure_db_to_brightway(name="super-db")
 
 
+def test_write_superstructure_to_brightway_uses_fast_writer_after_full_preparation(
+    monkeypatch,
+):
+    original_database = [{"name": "original"}]
+    exported_database = [{"name": "superstructure dataset", "exchanges": []}]
+    prepared_database = [{"name": "prepared superstructure", "exchanges": []}]
+    captured = {
+        "loaded": [],
+        "prepared": [],
+        "prepared_export": None,
+        "written": None,
+        "ended": [],
+        "pickles_deleted": 0,
+    }
+
+    def fake_load_database(scenario, original_database, load_metadata, warning=True):
+        captured["loaded"].append(
+            {
+                "scenario": scenario.copy(),
+                "original_database": original_database,
+                "load_metadata": load_metadata,
+                "warning": warning,
+            }
+        )
+        loaded = scenario.copy()
+        loaded["database"] = [{"name": f"loaded-{scenario['year']}", "exchanges": []}]
+        return loaded
+
+    def fake_prepare_database(
+        scenario,
+        db_name,
+        original_database,
+        biosphere_name,
+        version,
+    ):
+        captured["prepared"].append(
+            {
+                "scenario": scenario.copy(),
+                "db_name": db_name,
+                "original_database": original_database,
+                "biosphere_name": biosphere_name,
+                "version": version,
+            }
+        )
+
+    def fail_prepare_db_for_fast_export(*args, **kwargs):
+        raise AssertionError("superstructure export should keep full preparation")
+
+    def fake_generate_superstructure_db(
+        origin_db,
+        scenarios,
+        db_name,
+        biosphere_name,
+        filepath,
+        version,
+        file_format,
+        scenario_list,
+        preserve_original_column,
+    ):
+        assert origin_db == original_database
+        assert scenarios == obj.scenarios
+        assert db_name == "super-db"
+        assert biosphere_name == "test-biosphere"
+        assert filepath is None
+        assert version == "3.12"
+        assert file_format == "csv"
+        assert scenario_list == ["scenario-a", "scenario-b"]
+        assert preserve_original_column is False
+        return exported_database
+
+    def fake_prepare_db_for_export(
+        scenario,
+        name,
+        original_database,
+        biosphere_name,
+        version,
+    ):
+        captured["prepared_export"] = {
+            "scenario": scenario.copy(),
+            "name": name,
+            "original_database": original_database,
+            "biosphere_name": biosphere_name,
+            "version": version,
+        }
+        return prepared_database
+
+    def fake_write_brightway_database(data, name, fast=False, check_internal=True):
+        captured["written"] = {
+            "data": data,
+            "name": name,
+            "fast": fast,
+            "check_internal": check_internal,
+        }
+
+    monkeypatch.setattr(
+        new_database_module,
+        "check_presence_biosphere_database",
+        lambda _: None,
+    )
+    monkeypatch.setattr(new_database_module, "load_database", fake_load_database)
+    monkeypatch.setattr(new_database_module, "_prepare_database", fake_prepare_database)
+    monkeypatch.setattr(
+        new_database_module,
+        "prepare_db_for_fast_export",
+        fail_prepare_db_for_fast_export,
+    )
+    monkeypatch.setattr(
+        new_database_module,
+        "create_scenario_list",
+        lambda scenarios: ["scenario-a", "scenario-b"],
+    )
+    monkeypatch.setattr(
+        new_database_module,
+        "generate_superstructure_db",
+        fake_generate_superstructure_db,
+    )
+    monkeypatch.setattr(
+        new_database_module,
+        "prepare_db_for_export",
+        fake_prepare_db_for_export,
+    )
+    monkeypatch.setattr(
+        new_database_module,
+        "write_brightway_database",
+        fake_write_brightway_database,
+    )
+    monkeypatch.setattr(
+        new_database_module,
+        "end_of_process",
+        lambda scenario: captured["ended"].append(scenario.copy()),
+    )
+    monkeypatch.setattr(
+        new_database_module,
+        "delete_all_pickles",
+        lambda: captured.__setitem__("pickles_deleted", captured["pickles_deleted"] + 1),
+    )
+
+    obj = object.__new__(NewDatabase)
+    obj.biosphere_name = "test-biosphere"
+    obj.version = "3.12"
+    obj.generate_reports = False
+    obj.scenarios = [
+        {"model": "image", "pathway": "SSP2-Base", "year": 2030},
+        {"model": "image", "pathway": "SSP2-Base", "year": 2035},
+    ]
+    obj._load_original_database = lambda: original_database
+
+    obj.write_superstructure_db_to_brightway(name="super-db")
+
+    assert len(captured["loaded"]) == 2
+    assert all(call["load_metadata"] is True for call in captured["loaded"])
+    assert len(captured["prepared"]) == 2
+    assert all(call["db_name"] == "super-db" for call in captured["prepared"])
+    assert captured["prepared_export"] == {
+        "scenario": {
+            "model": "image",
+            "pathway": "SSP2-Base",
+            "year": 2030,
+            "database": exported_database,
+        },
+        "name": "super-db",
+        "original_database": original_database,
+        "biosphere_name": "test-biosphere",
+        "version": "3.12",
+    }
+    assert captured["written"] == {
+        "data": prepared_database,
+        "name": "super-db",
+        "fast": True,
+        "check_internal": False,
+    }
+    assert captured["ended"] == obj.scenarios
+    assert captured["pickles_deleted"] == 1
+
+
 def test_pathways_datapackage_does_not_prevalidate_biosphere_database(monkeypatch):
     captured = {}
 

--- a/tests/test_new_database.py
+++ b/tests/test_new_database.py
@@ -206,6 +206,184 @@ def test_write_db_to_brightway_requires_registered_biosphere(monkeypatch):
         obj.write_db_to_brightway(name=["test-db"])
 
 
+def test_write_db_to_brightway_fast_path_runs_internal_check(monkeypatch):
+    prepared_database = [{"name": "prepared dataset", "exchanges": []}]
+    captured = {
+        "loaded": None,
+        "prepared": None,
+        "written": None,
+        "ended": [],
+        "pickles_deleted": 0,
+    }
+
+    def fake_load_database(scenario, original_database, load_metadata, warning=True):
+        captured["loaded"] = {
+            "scenario": scenario.copy(),
+            "original_database": original_database,
+            "load_metadata": load_metadata,
+            "warning": warning,
+        }
+        loaded = scenario.copy()
+        loaded["database"] = [{"name": "loaded dataset", "exchanges": []}]
+        return loaded
+
+    def fake_prepare_db_for_fast_export(scenario, name, biosphere_name, version):
+        captured["prepared"] = {
+            "scenario": scenario.copy(),
+            "name": name,
+            "biosphere_name": biosphere_name,
+            "version": version,
+        }
+        return prepared_database
+
+    def fake_write_brightway_database(data, name, fast=False, check_internal=True):
+        captured["written"] = {
+            "data": data,
+            "name": name,
+            "fast": fast,
+            "check_internal": check_internal,
+        }
+
+    monkeypatch.setattr(
+        new_database_module,
+        "check_presence_biosphere_database",
+        lambda _: None,
+    )
+    monkeypatch.setattr(new_database_module, "load_database", fake_load_database)
+    monkeypatch.setattr(
+        new_database_module,
+        "prepare_db_for_fast_export",
+        fake_prepare_db_for_fast_export,
+    )
+    monkeypatch.setattr(
+        new_database_module,
+        "write_brightway_database",
+        fake_write_brightway_database,
+    )
+    monkeypatch.setattr(
+        new_database_module,
+        "end_of_process",
+        lambda scenario: captured["ended"].append(scenario.copy()),
+    )
+    monkeypatch.setattr(
+        new_database_module,
+        "delete_all_pickles",
+        lambda: captured.__setitem__("pickles_deleted", captured["pickles_deleted"] + 1),
+    )
+
+    obj = object.__new__(NewDatabase)
+    obj.biosphere_name = "test-biosphere"
+    obj.version = "3.12"
+    obj.generate_reports = False
+    obj.scenarios = [
+        {
+            "model": "image",
+            "pathway": "SSP2-Base",
+            "year": 2030,
+            "database filepath": Path("scenario-cache.pickle"),
+        }
+    ]
+    obj._load_original_database = lambda: (_ for _ in ()).throw(
+        AssertionError("fast export path should not reload the original database")
+    )
+
+    obj.write_db_to_brightway(name="fast-db")
+
+    assert captured["loaded"] == {
+        "scenario": {
+            "model": "image",
+            "pathway": "SSP2-Base",
+            "year": 2030,
+            "database filepath": Path("scenario-cache.pickle"),
+        },
+        "original_database": [],
+        "load_metadata": True,
+        "warning": False,
+    }
+    assert captured["prepared"] == {
+        "scenario": {
+            "model": "image",
+            "pathway": "SSP2-Base",
+            "year": 2030,
+            "database filepath": Path("scenario-cache.pickle"),
+            "database": [{"name": "loaded dataset", "exchanges": []}],
+        },
+        "name": "fast-db",
+        "biosphere_name": "test-biosphere",
+        "version": "3.12",
+    }
+    assert captured["written"] == {
+        "data": prepared_database,
+        "name": "fast-db",
+        "fast": True,
+        "check_internal": True,
+    }
+    assert captured["ended"] == [
+        {
+            "model": "image",
+            "pathway": "SSP2-Base",
+            "year": 2030,
+            "database filepath": Path("scenario-cache.pickle"),
+            "database": prepared_database,
+            "database name": "fast-db",
+        }
+    ]
+    assert captured["pickles_deleted"] == 1
+
+
+def test_write_db_to_brightway_fast_path_reports_major_validation_errors(monkeypatch):
+    captured = {"reports": 0}
+
+    monkeypatch.setattr(
+        new_database_module,
+        "check_presence_biosphere_database",
+        lambda _: None,
+    )
+    monkeypatch.setattr(
+        new_database_module,
+        "load_database",
+        lambda scenario, original_database, load_metadata, warning=True: scenario.copy(),
+    )
+    monkeypatch.setattr(
+        new_database_module,
+        "prepare_db_for_fast_export",
+        lambda **kwargs: (_ for _ in ()).throw(ValueError("major issue")),
+    )
+    monkeypatch.setattr(
+        new_database_module,
+        "write_brightway_database",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("writer should not be called after validation failure")
+        ),
+    )
+    monkeypatch.setattr(new_database_module, "end_of_process", lambda scenario: None)
+    monkeypatch.setattr(new_database_module, "delete_all_pickles", lambda: None)
+
+    obj = object.__new__(NewDatabase)
+    obj.biosphere_name = "test-biosphere"
+    obj.version = "3.12"
+    obj.generate_reports = False
+    obj.scenarios = [
+        {
+            "model": "image",
+            "pathway": "SSP2-Base",
+            "year": 2030,
+            "database filepath": Path("scenario-cache.pickle"),
+        }
+    ]
+    obj.generate_change_report = lambda: captured.__setitem__(
+        "reports", captured["reports"] + 1
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="The database is not ready for export: MAJOR anomalies found. Check the change report.",
+    ):
+        obj.write_db_to_brightway(name="fast-db")
+
+    assert captured["reports"] == 1
+
+
 def test_write_superstructure_to_brightway_requires_registered_biosphere(monkeypatch):
     monkeypatch.setattr(new_database_module.bw2data, "databases", {})
 


### PR DESCRIPTION
## Summary

  This PR refactors the `NewDatabase -> update() -> write_db_to_brightway()` path to reduce
  export-time RSS and runtime, while keeping exported databases usable as normal Brightway
  databases.

  Compared to `master`, the branch introduces:
  - a fast Brightway 2.5 export path that writes rows and processed arrays directly
  - compact shard-backed scenario caches for post-`update()` databases
  - streamed cold extraction of the Brightway source database to reduce init RSS
  - a fast writer path for superstructure exports after full preparation
  - stronger core validation on the regular fast export path
  - fixes for migrated inventory gap filling
  - clearer export progress and completion messages

  ## What changed

  ### Fast Brightway export
  - Reworked the Brightway 2.5 export path to avoid the usual “write all rows, then let
  Brightway reprocess them back out” cycle.
  - The fast path now writes:
    - normal Brightway activity rows
    - normal Brightway exchange rows
    - processed matrices
    - the search index
  - Exported databases remain usable from plain `bw2data`, including browsing and search
  behavior.

  ### Leaner scenario caching
  - Post-`update()` scenario databases are now cached in compact shard-backed files with
  metadata stored separately.
  - Reloading restores preserved codes and merges back dataset/exchange metadata only when
  needed.
  - This reduces in-memory duplication and helps the fast export path avoid loading the
  heaviest representation unnecessarily.

  ### Lower cold-start memory
  - Brightway source extraction now iterates over Peewee querysets with `.iterator()`
  instead of caching full query objects during extraction.
  - This reduces the RSS spike during cold `NewDatabase()` initialization.

  ### Superstructure export
  - `write_superstructure_db_to_brightway()` now keeps the full preparation/validation flow
  and only swaps the final serialization step to the fast writer.

  ### Validation and UX
  - The regular fast `write_db_to_brightway()` path now runs core export checks and re-
  enables internal-link validation before writing.
  - Fast exports now show progress bars for major stages and print explicit overwrite/write
  messages.

  ### Inventory import fix
  - Fixed replacement-based gap filling for migrated inventories so split placeholder
  exchanges are replaced with the correct supplier structure instead of duplicating amounts
  across every migrated split.

  ## Performance

  Local warm cached benchmark against `master`:

  - total runtime: `264.1 s -> 193.7 s` (`-26.6%`)
  - peak RSS: `3.05 GiB -> 1.80 GiB` (`-41.0%`)
  - `write_db_to_brightway()`: `157.7 s -> 52.7 s` (`-66.6%`)

  The biggest gain remains in the Brightway export phase. The later fast-path validation
  tightening adds some overhead relative to the leanest experimental version, but the branch
  still materially reduces export RSS and runtime versus `master`.

  ## Validation

  Targeted tests run locally:
  - `pytest tests/test_brightway_writers.py tests/test_export.py tests/test_new_database.py
  -k "brightway_writers or prepare_db_for_fast_export or write_db_to_brightway or
  write_superstructure or inventory_cache_miss"`
  - `pytest tests/test_import_inventories.py -k "fill_data_gaps or fill_dataset_data_gaps"`

  Results:
  - `12 passed`
  - `2 passed`

  During branch development, the fast export path was also checked for LCIA parity on a
  `1000 activities x 6 methods` sample and matched exactly.

  ## Notes

  - The regular fast export path now runs stronger core validation, but it still does not
  use the full `prepare_db_for_export()` stack used by the slow path.
  - Superstructure export is more conservative: it still performs full preparation first,
  then uses the fast writer only as the final serialization backend.
  - This PR also includes small Brightway writer UX improvements:
    - progress bars during fast export
    - explicit overwrite notice
    - explicit `Brightway database written: <name>` completion message
    - removal of the noisy geocollection warning on fast exports
